### PR TITLE
Add app key field for action nodes

### DIFF
--- a/src/components/nodes/action-node.tsx
+++ b/src/components/nodes/action-node.tsx
@@ -69,6 +69,9 @@ export function ActionNode({ id, data, type }: WorkflowNodeProps) {
         <p>
           Selected Action: <strong>{data.actionType || 'None'}</strong>
         </p>
+        <p className="mt-1">
+          Selected App: <strong>{data.appKey || 'None'}</strong>
+        </p>
 
         <Input
           placeholder="Listing ID"

--- a/src/components/nodes/index.tsx
+++ b/src/components/nodes/index.tsx
@@ -33,6 +33,11 @@ export type WorkflowNodeData = {
   listingId?: string;
   actionId?: string;
   actionType?: string;
+  /**
+   * Key of the application the action belongs to. This is set when an
+   * action is chosen in the side panel and displayed within the node.
+   */
+  appKey?: string;
 };
 
 export type WorkflowNodeProps = NodeProps<Node<WorkflowNodeData>> & {

--- a/src/components/nodes/node-details/action-node-detail.tsx
+++ b/src/components/nodes/node-details/action-node-detail.tsx
@@ -13,7 +13,11 @@ export const ActionNodeDetail = ({ node }: NodeDetailProps) => {
   const { actions } = useActions(selectedApp ?? undefined);
 
   const handleActionSelect = (action: Action) => {
-    setNodeData(node.id, { actionType: action.id, title: action.title });
+    setNodeData(node.id, {
+      appKey: selectedApp ?? undefined,
+      actionType: action.id,
+      title: action.title,
+    });
   };
 
   const mappedActions = (actions || []).map((a: any) => ({

--- a/src/components/nodes/node-details/types.ts
+++ b/src/components/nodes/node-details/types.ts
@@ -26,5 +26,9 @@ export type WorkflowNodeData = {
     actionType?: string;  // <-- add this if not already present
     listingId?: string;
     quantity?: number;
+    /**
+     * Key of the application selected for this action node.
+     */
+    appKey?: string;
   };
   


### PR DESCRIPTION
## Summary
- add optional `appKey` to `WorkflowNodeData` types
- persist selected app when choosing an action
- display the selected app in `ActionNode`

## Testing
- `npm run lint` *(fails: How would you like to configure ESLint?)*