### PR TITLE
Configure API routes to talk to running backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,18 @@ To get started, follow these steps:
    bun install
    ```
 
-2. **Run the development server**:
+2. **Start the backend**:
+
+   ```bash
+   # Using Docker
+   cd automat
+   docker-compose up
+
+   # Or run the Node server directly
+   node packages/backend/src/server.js
+   ```
+
+3. **Run the development server**:
 
    ```bash
    npm run dev
@@ -40,7 +51,13 @@ To get started, follow these steps:
    bun dev
    ```
 
-3. Open your browser and navigate to `http://localhost:3000`.
+4. Open your browser and navigate to `http://localhost:3000`.
+
+The API routes use the `BACKEND_URL` environment variable to reach the backend. If you run the backend on a different host or port, create a `.env.local` file and set:
+
+```bash
+BACKEND_URL=http://localhost:3000
+```
 
 ## Tech Stack
 

--- a/src/app/api/apps/[appKey]/actions/route.ts
+++ b/src/app/api/apps/[appKey]/actions/route.ts
@@ -1,10 +1,19 @@
 import { NextRequest, NextResponse } from 'next/server';
-import App from '../../../../../../automat/packages/backend/src/models/app.js';
+
+const backendUrl = process.env.BACKEND_URL || 'http://localhost:3000';
 
 export async function GET(request: NextRequest, context: { params: { appKey: string } }) {
   const { appKey } = context.params;
   try {
-    const actions = await App.findActionsByKey(appKey);
+    const url = `${backendUrl}/internal/api/v1/apps/${appKey}/actions`;
+    const res = await fetch(url);
+
+    if (!res.ok) {
+      throw new Error(await res.text());
+    }
+
+    const actions = await res.json();
+
     return NextResponse.json(actions);
   } catch (error: any) {
     return NextResponse.json({ error: error.message }, { status: 500 });

--- a/src/app/api/apps/[appKey]/triggers/route.ts
+++ b/src/app/api/apps/[appKey]/triggers/route.ts
@@ -1,10 +1,19 @@
 import { NextRequest, NextResponse } from 'next/server';
-import App from '../../../../../../automat/packages/backend/src/models/app.js';
+
+const backendUrl = process.env.BACKEND_URL || 'http://localhost:3000';
 
 export async function GET(request: NextRequest, context: { params: { appKey: string } }) {
   const { appKey } = context.params;
   try {
-    const triggers = await App.findTriggersByKey(appKey);
+    const url = `${backendUrl}/internal/api/v1/apps/${appKey}/triggers`;
+    const res = await fetch(url);
+
+    if (!res.ok) {
+      throw new Error(await res.text());
+    }
+
+    const triggers = await res.json();
+
     return NextResponse.json(triggers);
   } catch (error: any) {
     return NextResponse.json({ error: error.message }, { status: 500 });

--- a/src/app/api/apps/route.ts
+++ b/src/app/api/apps/route.ts
@@ -1,9 +1,18 @@
 import { NextRequest, NextResponse } from 'next/server';
-import App from '../../../../automat/packages/backend/src/models/app.js';
+
+const backendUrl = process.env.BACKEND_URL || 'http://localhost:3000';
 
 export async function GET(request: NextRequest) {
   try {
-    const apps = await App.findAll();
+    const url = `${backendUrl}/internal/api/v1/apps${request.nextUrl.search}`;
+    const res = await fetch(url);
+
+    if (!res.ok) {
+      throw new Error(await res.text());
+    }
+
+    const apps = await res.json();
+
     return NextResponse.json(apps);
   } catch (error: any) {
     return NextResponse.json({ error: error.message }, { status: 500 });


### PR DESCRIPTION
## Summary
- fetch backend data via HTTP instead of importing server modules
- document backend setup in README

## Testing
- `npm run lint` *(fails: Next.js prompts to configure ESLint)*
- `npm test` *(fails: no test script)*