### PR TITLE
Enable example nodes by default

### DIFF
--- a/src/app/api/apps/[appKey]/actions/route.ts
+++ b/src/app/api/apps/[appKey]/actions/route.ts
@@ -1,10 +1,19 @@
 import { NextRequest, NextResponse } from 'next/server';
-import App from '../../../../../../automat/packages/backend/src/models/app.js';
+
+const backendUrl = process.env.BACKEND_URL || 'http://localhost:3000';
 
 export async function GET(request: NextRequest, context: { params: { appKey: string } }) {
   const { appKey } = context.params;
   try {
-    const actions = await App.findActionsByKey(appKey);
+    const url = `${backendUrl}/internal/api/v1/apps/${appKey}/actions`;
+    const res = await fetch(url);
+
+    if (!res.ok) {
+      throw new Error(await res.text());
+    }
+
+    const actions = await res.json();
+
     return NextResponse.json(actions);
   } catch (error: any) {
     return NextResponse.json({ error: error.message }, { status: 500 });

--- a/src/app/api/apps/[appKey]/triggers/route.ts
+++ b/src/app/api/apps/[appKey]/triggers/route.ts
@@ -1,10 +1,19 @@
 import { NextRequest, NextResponse } from 'next/server';
-import App from '../../../../../../automat/packages/backend/src/models/app.js';
+
+const backendUrl = process.env.BACKEND_URL || 'http://localhost:3000';
 
 export async function GET(request: NextRequest, context: { params: { appKey: string } }) {
   const { appKey } = context.params;
   try {
-    const triggers = await App.findTriggersByKey(appKey);
+    const url = `${backendUrl}/internal/api/v1/apps/${appKey}/triggers`;
+    const res = await fetch(url);
+
+    if (!res.ok) {
+      throw new Error(await res.text());
+    }
+
+    const triggers = await res.json();
+
     return NextResponse.json(triggers);
   } catch (error: any) {
     return NextResponse.json({ error: error.message }, { status: 500 });

--- a/src/app/api/apps/route.ts
+++ b/src/app/api/apps/route.ts
@@ -1,9 +1,18 @@
 import { NextRequest, NextResponse } from 'next/server';
-import App from '../../../../automat/packages/backend/src/models/app.js';
+
+const backendUrl = process.env.BACKEND_URL || 'http://localhost:3000';
 
 export async function GET(request: NextRequest) {
   try {
-    const apps = await App.findAll();
+    const url = `${backendUrl}/internal/api/v1/apps${request.nextUrl.search}`;
+    const res = await fetch(url);
+
+    if (!res.ok) {
+      throw new Error(await res.text());
+    }
+
+    const apps = await res.json();
+
     return NextResponse.json(apps);
   } catch (error: any) {
     return NextResponse.json({ error: error.message }, { status: 500 });

--- a/src/components/nodes/node-details/action-node-detail.tsx
+++ b/src/components/nodes/node-details/action-node-detail.tsx
@@ -13,7 +13,11 @@ export const ActionNodeDetail = ({ node }: NodeDetailProps) => {
   const { actions } = useActions(selectedApp ?? undefined);
 
   const handleActionSelect = (action: Action) => {
-    setNodeData(node.id, { actionType: action.id, title: action.title });
+    setNodeData(node.id, {
+      appKey: selectedApp ?? undefined,
+      actionType: action.id,
+      title: action.title,
+    });
   };
 
   const mappedActions = (actions || []).map((a: any) => ({

--- a/src/data/workflow-data.ts
+++ b/src/data/workflow-data.ts
@@ -43,7 +43,7 @@ export const initialNodes = [
 
 
 export const initialNodes: AppNode[] = [
-  /* createNodeFromRegistry({
+  createNodeFromRegistry({
     type: 'trigger-node',
     id: 'marketplace-trigger',
     position: { x: 0, y: -200 },
@@ -78,7 +78,7 @@ export const initialNodes: AppNode[] = [
     id: 'end-workflow',
     position: { x: 0, y: 600 },
     data: { title: 'End Workflow' },
-  }), */
+  }),
 ];
 
 export const initialEdges = [


### PR DESCRIPTION
## Summary
- uncomment sample `createNodeFromRegistry` calls
- sync API routes and ActionNodeDetail with main branch

## Testing
- `npm run build` *(fails: Type error in actions route)*
