### PR TITLE
Remove console.log debug statements

### DIFF
--- a/src/app/api/deepseek/route.ts
+++ b/src/app/api/deepseek/route.ts
@@ -90,7 +90,7 @@ Provide ONLY the JSON response without markdown or code fences.
   
     const data = await response.json();
   
-    console.log("DeepSeek Raw API Response:", data);
+    console.debug('DeepSeek Raw API Response:', data);
   
     // Extract and clean markdown-wrapped JSON
     let jsonResponse;
@@ -112,7 +112,7 @@ Provide ONLY the JSON response without markdown or code fences.
       });
     }
   
-    console.log("Parsed JSON Response:", jsonResponse);
+    console.debug('Parsed JSON Response:', jsonResponse);
   
     return new Response(JSON.stringify(jsonResponse), {
       status: 200,

--- a/src/components/nodes/ai-node.tsx
+++ b/src/components/nodes/ai-node.tsx
@@ -35,7 +35,7 @@ interface AINodeProps {
       });
 
       //const textResponse = await response.text(); // first get raw text for debug
-      //console.log("Raw Response from Backend:", textResponse);
+      //console.debug('Raw Response from Backend:', textResponse);
 
       if (!response.ok) {
         throw new Error(`API error: ${response.status}`);
@@ -43,7 +43,7 @@ interface AINodeProps {
       }
       
       const jsonResponse = await response.json();
-      console.log("Raw Response from Backend:", jsonResponse);
+      console.debug('Raw Response from Backend:', jsonResponse);
 
       if (!jsonResponse.nodes || !jsonResponse.edges) {
         console.error("Malformed JSON structure:", jsonResponse);
@@ -78,9 +78,9 @@ interface AINodeProps {
 
     //   setNodes(json.nodes);
     //   setEdges(json.edges);
-// ADD THESE LINES:
-console.log("Nodes after setNodes:", formattedNodes);
-      console.log("Edges after setEdges:", formattedEdges);
+// Debug output for newly created nodes and edges
+      console.debug('Nodes after setNodes:', formattedNodes);
+      console.debug('Edges after setEdges:', formattedEdges);
     } catch (err) {
       console.error('Failed to generate AI workflow:', err);
     } finally {

--- a/src/components/workflow/index.tsx
+++ b/src/components/workflow/index.tsx
@@ -42,8 +42,8 @@ export default function Workflow() {
     }))
   );
 
-  console.log('Nodes passed into ReactFlow:', nodes);
-  console.log('Edges passed into ReactFlow:', edges);
+  console.debug('Nodes passed into ReactFlow:', nodes);
+  console.debug('Edges passed into ReactFlow:', edges);
   const { onDragOver, onDrop } = useDragAndDrop();
   const runLayout = useLayout(true);
 

--- a/src/hooks/use-workflow-runner.tsx
+++ b/src/hooks/use-workflow-runner.tsx
@@ -10,7 +10,7 @@ import { AppEdge } from '@/components/edges';
 export function useWorkflowRunner() {
   const [logMessages, setLogMessages] = useState<string[]>([]);
   useEffect(() => {
-    console.log("Workflow Logs:", logMessages);
+    console.debug('Workflow Logs:', logMessages);
   }, [logMessages]);
   const isRunning = useRef(false);
 

--- a/src/store/app-store.ts
+++ b/src/store/app-store.ts
@@ -131,12 +131,12 @@ export const createAppStore = (initialState: AppState = defaultState) => {
       },
 
       setNodes: (nodes) => {
-        console.log('🚀 Zustand nodes updated:', nodes);
+        console.debug('Zustand nodes updated:', nodes);
         set({ nodes });
       },
       
       setEdges: (edges) => {
-        console.log('🚀 Zustand edges updated:', edges);
+        console.debug('Zustand edges updated:', edges);
         set({ edges });
       },
       setSelectedNode: (node) => set({ selectedNode: node }),


### PR DESCRIPTION
## Summary
- clean up console.log usage across the Next.js app
- replace debugging statements with `console.debug`

## Testing
- `npm run lint` *(fails: prompts for interactive setup)*