### PR TITLE
Forward auth header to backend

### DIFF
--- a/src/app/api/apps/[appKey]/actions/route.ts
+++ b/src/app/api/apps/[appKey]/actions/route.ts
@@ -4,17 +4,19 @@ const backendUrl = process.env.BACKEND_URL || 'http://localhost:3000';
 
 export async function GET(request: NextRequest, context: { params: { appKey: string } }) {
   const { appKey } = context.params;
+  const token = request.headers.get('authorization');
   try {
     const url = `${backendUrl}/internal/api/v1/apps/${appKey}/actions`;
-    const res = await fetch(url);
-
-    if (!res.ok) {
-      throw new Error(await res.text());
+    const headers: HeadersInit = {};
+    if (token) {
+      headers['Authorization'] = token;
     }
+    const res = await fetch(url, { headers });
 
-    const actions = await res.json();
-
-    return NextResponse.json(actions);
+    return new NextResponse(res.body, {
+      status: res.status,
+      headers: res.headers,
+    });
   } catch (error: any) {
     return NextResponse.json({ error: error.message }, { status: 500 });
   }

--- a/src/app/api/apps/[appKey]/triggers/route.ts
+++ b/src/app/api/apps/[appKey]/triggers/route.ts
@@ -4,17 +4,19 @@ const backendUrl = process.env.BACKEND_URL || 'http://localhost:3000';
 
 export async function GET(request: NextRequest, context: { params: { appKey: string } }) {
   const { appKey } = context.params;
+  const token = request.headers.get('authorization');
   try {
     const url = `${backendUrl}/internal/api/v1/apps/${appKey}/triggers`;
-    const res = await fetch(url);
-
-    if (!res.ok) {
-      throw new Error(await res.text());
+    const headers: HeadersInit = {};
+    if (token) {
+      headers['Authorization'] = token;
     }
+    const res = await fetch(url, { headers });
 
-    const triggers = await res.json();
-
-    return NextResponse.json(triggers);
+    return new NextResponse(res.body, {
+      status: res.status,
+      headers: res.headers,
+    });
   } catch (error: any) {
     return NextResponse.json({ error: error.message }, { status: 500 });
   }

--- a/src/app/api/apps/route.ts
+++ b/src/app/api/apps/route.ts
@@ -3,17 +3,19 @@ import { NextRequest, NextResponse } from 'next/server';
 const backendUrl = process.env.BACKEND_URL || 'http://localhost:3000';
 
 export async function GET(request: NextRequest) {
+  const token = request.headers.get('authorization');
   try {
     const url = `${backendUrl}/internal/api/v1/apps${request.nextUrl.search}`;
-    const res = await fetch(url);
-
-    if (!res.ok) {
-      throw new Error(await res.text());
+    const headers: HeadersInit = {};
+    if (token) {
+      headers['Authorization'] = token;
     }
+    const res = await fetch(url, { headers });
 
-    const apps = await res.json();
-
-    return NextResponse.json(apps);
+    return new NextResponse(res.body, {
+      status: res.status,
+      headers: res.headers,
+    });
   } catch (error: any) {
     return NextResponse.json({ error: error.message }, { status: 500 });
   }


### PR DESCRIPTION
## Summary
- propagate Authorization header when calling backend
- pass along backend response status and headers

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*