### PR TITLE
Read auth token for app hooks

### DIFF
--- a/src/hooks/use-actions.ts
+++ b/src/hooks/use-actions.ts
@@ -1,5 +1,6 @@
 'use client';
 import { useEffect, useState } from 'react';
+import { getAuthToken } from '@/lib/auth';
 
 export function useActions(appKey?: string) {
   const [actions, setActions] = useState<any[] | null>(null);
@@ -14,7 +15,12 @@ export function useActions(appKey?: string) {
       setError(null);
 
       try {
-        const res = await fetch(`/api/apps/${appKey}/actions`);
+        const headers: HeadersInit = {};
+        const token = getAuthToken();
+        if (token) {
+          headers['Authorization'] = token;
+        }
+        const res = await fetch(`/api/apps/${appKey}/actions`, { headers });
         if (!res.ok) throw new Error('Failed to fetch actions');
         const json = await res.json();
         setActions(json.data);

--- a/src/hooks/use-apps.ts
+++ b/src/hooks/use-apps.ts
@@ -1,5 +1,6 @@
 'use client';
 import { useEffect, useState } from 'react';
+import { getAuthToken } from '@/lib/auth';
 
 export function useApps() {
   const [apps, setApps] = useState<any[] | null>(null);
@@ -11,7 +12,12 @@ export function useApps() {
       setIsLoading(true);
       setError(null);
       try {
-        const res = await fetch('/api/apps');
+        const headers: HeadersInit = {};
+        const token = getAuthToken();
+        if (token) {
+          headers['Authorization'] = token;
+        }
+        const res = await fetch('/api/apps', { headers });
         if (!res.ok) throw new Error('Failed to fetch apps');
         const json = await res.json();
         setApps(json.data);

--- a/src/hooks/use-triggers.ts
+++ b/src/hooks/use-triggers.ts
@@ -1,5 +1,6 @@
 'use client';
 import { useEffect, useState } from 'react';
+import { getAuthToken } from '@/lib/auth';
 
 export function useTriggers(appKey?: string) {
   const [triggers, setTriggers] = useState<any[] | null>(null);
@@ -14,7 +15,12 @@ export function useTriggers(appKey?: string) {
       setError(null);
 
       try {
-        const res = await fetch(`/api/apps/${appKey}/triggers`);
+        const headers: HeadersInit = {};
+        const token = getAuthToken();
+        if (token) {
+          headers['Authorization'] = token;
+        }
+        const res = await fetch(`/api/apps/${appKey}/triggers`, { headers });
         if (!res.ok) throw new Error('Failed to fetch triggers');
         const json = await res.json();
         setTriggers(json.data);

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,11 @@
+export function getAuthToken(): string | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const token = window.localStorage.getItem('automatisch.token');
+    if (token) return token;
+  } catch {
+    // ignore
+  }
+  const match = document.cookie.match(/(?:^|; )token=([^;]+)/);
+  return match ? decodeURIComponent(match[1]) : null;
+}


### PR DESCRIPTION
## Summary
- add helper to get auth token from local storage
- include Authorization header in apps, actions and triggers hooks

## Testing
- `npm run lint` *(fails: prompts for configuration)*