### PR TITLE
Fix gitignore merge markers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
 # dependencies
-/node_modules
+node_modules/
 /.pnp
 .pnp.js
 .yarn/install-state.gz
@@ -34,10 +34,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
-<<<<<<< HEAD
-node_modules/
-node_modules/
-=======
->>>>>>> 4f6461f848a74ce768491ac49ddfe559b5681d80
-node_modules/
 .DS_Store


### PR DESCRIPTION
## Summary
- remove leftover merge conflict markers from `.gitignore`
- keep a single `node_modules/` entry

## Testing
- `npm run lint` *(fails: requires interactive configuration)*