### PR TITLE
Remove obsolete inputs from ActionNode

### DIFF
--- a/src/components/nodes/action-node.tsx
+++ b/src/components/nodes/action-node.tsx
@@ -1,11 +1,9 @@
 'use client';
 
-import { useState, useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import nodesConfig, { WorkflowNodeProps, WorkflowNodeData } from '.';
 import WorkflowNode from './workflow-node';
 import { AppHandle } from './workflow-node/app-handle';
-import { Input } from '@/components/ui/input';
-import { useAppStore } from '@/store';
 import { NODE_SIZE } from '.';
 import {
     Position,
@@ -16,43 +14,8 @@ import {
     XYPosition,
   } from '@xyflow/react';
 export function ActionNode({ id, data, type }: WorkflowNodeProps) {
-  const [listingId, setListingId] = useState(data.listingId || '');
-  const [quantity, setQuantity] = useState(data.quantity?.toString() || '');
 
-  const setNodeData = useAppStore((state) => state.setNodeData);
   const nodeRef = useRef<HTMLDivElement>(null);
-  const [nodeHeight, setNodeHeight] = useState(50); // initial default height
-
-  useEffect(() => {
-    if (nodeRef.current) {
-      const { height } = nodeRef.current.getBoundingClientRect();
-      setNodeHeight(height);
-    }
-  }, [data.actionType, data.listingId, data.quantity]);
-
-  useEffect(() => {
-    setListingId(data.listingId || '');
-    setQuantity(data.quantity || 0);
-  }, [data.listingId, data.quantity]);
-
-  const handleListingIdChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const newId = e.target.value;
-    setListingId(newId);
-    setNodeData(id, { listingId: newId });
-  };
-
-  const handleQuantityChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const newQuantity = e.target.value;
-    setQuantity(newQuantity);
-    const numericQuantity = newQuantity === '' ? 0 : Number(newQuantity);
-    setNodeData(id, { quantity: numericQuantity });
-  };
-  function calculateBottomYPosition(data: WorkflowNodeData) {
-    const baseHeight = 60; // initial node header height
-    const fieldHeight = 42; // height per input field or detail line
-    const fieldCount = data.actionType ? 3 : 1; // example conditional field count
-    return baseHeight + fieldHeight * fieldCount;
-  }
 
   return (
     <WorkflowNode id={id} data={data} type={type} nodeRef={nodeRef}>
@@ -73,24 +36,6 @@ export function ActionNode({ id, data, type }: WorkflowNodeProps) {
           Selected App: <strong>{data.appKey || 'None'}</strong>
         </p>
 
-        <Input
-          placeholder="Listing ID"
-          value={listingId}
-          onChange={handleListingIdChange}
-          className="mt-2"
-        />
-
-        <Input
-          type="number"
-          placeholder="Quantity"
-          value={quantity}
-          onChange={(e) => {
-            e.stopPropagation();
-            handleQuantityChange(e);
-          }}
-          onClick={(e) => e.stopPropagation()}
-          className="mt-2"
-        />
       </div>
 
       {/* <AppHandle
@@ -98,7 +43,7 @@ export function ActionNode({ id, data, type }: WorkflowNodeProps) {
         type="source"
         position="bottom"
         x={NODE_SIZE.width / 2}
-        y={calculateBottomYPosition(data)} // dynamically calculate based on content height
+        y={50}
       /> */}
     </WorkflowNode>
   );


### PR DESCRIPTION
## Summary
- drop Listing ID and Quantity fields from `ActionNode`

## Testing
- `npm run lint` *(fails: `next` not found)*