### PR TITLE
Refactor API route handler parameters

### DIFF
--- a/src/app/api/apps/[appKey]/actions/route.ts
+++ b/src/app/api/apps/[appKey]/actions/route.ts
@@ -2,8 +2,11 @@ import { NextRequest, NextResponse } from 'next/server';
 
 const backendUrl = process.env.BACKEND_URL || 'http://localhost:3000';
 
-export async function GET(request: NextRequest, context: { params: { appKey: string } }) {
-  const { appKey } = context.params;
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { appKey: string } }
+) {
+  const { appKey } = params;
   const token = request.headers.get('authorization');
   try {
     const url = `${backendUrl}/internal/api/v1/apps/${appKey}/actions`;

--- a/src/app/api/apps/[appKey]/triggers/route.ts
+++ b/src/app/api/apps/[appKey]/triggers/route.ts
@@ -2,8 +2,11 @@ import { NextRequest, NextResponse } from 'next/server';
 
 const backendUrl = process.env.BACKEND_URL || 'http://localhost:3000';
 
-export async function GET(request: NextRequest, context: { params: { appKey: string } }) {
-  const { appKey } = context.params;
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { appKey: string } }
+) {
+  const { appKey } = params;
   const token = request.headers.get('authorization');
   try {
     const url = `${backendUrl}/internal/api/v1/apps/${appKey}/triggers`;


### PR DESCRIPTION
## Summary
- use param destructuring in apps API routes for GET handlers

## Testing
- `npm run build` *(fails: invalid `GET` export type)*

------
https://chatgpt.com/codex/tasks/task_e_684f616fba008329880b139f6ef16fc9