### PR TITLE
Add AGENTS instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,25 @@
+# Codex Agent Instructions
+
+## Testing and Linting
+- Run lint checks with `npm run lint`.
+- Backend tests are located in `automat/packages/backend`. Execute them with `yarn test` from that directory.
+
+## Coding Conventions
+- Use TypeScript and 2‑space indentation.
+- Prefer single quotes for strings.
+- Keep Next.js and React imports at the top of files.
+
+## Project Structure
+- Frontend code resides in `src/`.
+- The Node backend lives in `automat/packages/backend`.
+- Documentation lives in `automat/packages/docs`.
+
+## Build Instructions
+- Install dependencies with `npm install` (or `pnpm install`).
+- Start the frontend with `npm run dev`.
+- To run the backend, follow the instructions in `README.md` (e.g., `cd automat && docker-compose up` or `node packages/backend/src/server.js`).
+
+## General Guidance
+- Prefer functional React components.
+- Avoid adding external state management libraries beyond the existing `zustand` store.
+- Keep code modular under `src/components`, `src/hooks`, etc.


### PR DESCRIPTION
## Summary
- provide Codex usage instructions in `AGENTS.md`

## Testing
- `npm run lint` *(fails: Definition for rule '@typescript-eslint/no-empty-object-type' was not found)*
- `yarn test` in `automat/packages/backend` *(fails: cannot find package 'pg')*

------
https://chatgpt.com/codex/tasks/task_e_684f6644344083298a8b9803d259801a