### PR TITLE
Fix DeepSeek API key constant usage

### DIFF
--- a/src/app/api/deepseek/route.ts
+++ b/src/app/api/deepseek/route.ts
@@ -8,7 +8,7 @@ export async function POST(request: NextRequest) {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': `Bearer ${process.env.DEEPSEEK_API_KEY}`
+        'Authorization': `Bearer ${DEEPSEEK_API_KEY}`
       },
       body: JSON.stringify({
         model: "deepseek-chat",


### PR DESCRIPTION
## Summary
- use the `DEEPSEEK_API_KEY` constant when sending auth header for DeepSeek API

## Testing
- `npm run lint`
- `yarn test` *(fails: Cannot find package 'pg')*

------
https://chatgpt.com/codex/tasks/task_e_684f74e2c1a08329bab5a8b48901e35f