### PR TITLE
Add mock app data for action node

### DIFF
--- a/src/data/mock-actions.ts
+++ b/src/data/mock-actions.ts
@@ -1,0 +1,18 @@
+export const mockActions: Record<string, { key: string; name: string }[]> = {
+  gmail: [
+    { key: 'send-email', name: 'Send Email' },
+    { key: 'search-emails', name: 'Search Emails' },
+  ],
+  slack: [
+    { key: 'post-message', name: 'Post Message' },
+    { key: 'create-channel', name: 'Create Channel' },
+  ],
+  github: [
+    { key: 'create-issue', name: 'Create Issue' },
+    { key: 'list-repos', name: 'List Repositories' },
+  ],
+  notion: [
+    { key: 'create-page', name: 'Create Page' },
+    { key: 'update-database', name: 'Update Database' },
+  ],
+};

--- a/src/data/mock-apps.ts
+++ b/src/data/mock-apps.ts
@@ -1,0 +1,6 @@
+export const mockApps = [
+  { key: 'gmail', name: 'Gmail' },
+  { key: 'slack', name: 'Slack' },
+  { key: 'github', name: 'GitHub' },
+  { key: 'notion', name: 'Notion' },
+];

--- a/src/hooks/use-actions.ts
+++ b/src/hooks/use-actions.ts
@@ -1,6 +1,7 @@
 'use client';
 import { useEffect, useState } from 'react';
 import { getAuthToken } from '@/lib/auth';
+import { mockActions } from '@/data/mock-actions';
 
 export function useActions(appKey?: string) {
   const [actions, setActions] = useState<any[] | null>(null);
@@ -25,6 +26,7 @@ export function useActions(appKey?: string) {
         const json = await res.json();
         setActions(json.data);
       } catch (err) {
+        setActions(mockActions[appKey] || []);
         setError(err as Error);
       } finally {
         setIsLoading(false);

--- a/src/hooks/use-apps.ts
+++ b/src/hooks/use-apps.ts
@@ -1,6 +1,7 @@
 'use client';
 import { useEffect, useState } from 'react';
 import { getAuthToken } from '@/lib/auth';
+import { mockApps } from '@/data/mock-apps';
 
 export function useApps() {
   const [apps, setApps] = useState<any[] | null>(null);
@@ -22,6 +23,7 @@ export function useApps() {
         const json = await res.json();
         setApps(json.data);
       } catch (err) {
+        setApps(mockApps);
         setError(err as Error);
       } finally {
         setIsLoading(false);


### PR DESCRIPTION
## Summary
- add mock apps and actions for fallback usage
- use fallback data in `useApps` and `useActions` when API calls fail

## Testing
- `npm run lint`
- `yarn test` *(fails: .env.test file missing)*

------
https://chatgpt.com/codex/tasks/task_e_684f8dff0be08329ba8c32921e2016d2