### PR TITLE
Add mock triggers fallback

### DIFF
--- a/src/data/mock-triggers.ts
+++ b/src/data/mock-triggers.ts
@@ -1,0 +1,18 @@
+export const mockTriggers: Record<string, { key: string; name: string }[]> = {
+  gmail: [
+    { key: 'new-email', name: 'New Email' },
+    { key: 'label-added', name: 'Label Added' },
+  ],
+  slack: [
+    { key: 'new-message', name: 'New Message' },
+    { key: 'channel-created', name: 'Channel Created' },
+  ],
+  github: [
+    { key: 'push', name: 'Push' },
+    { key: 'new-issue', name: 'New Issue' },
+  ],
+  notion: [
+    { key: 'page-created', name: 'Page Created' },
+    { key: 'database-updated', name: 'Database Updated' },
+  ],
+};

--- a/src/hooks/use-triggers.ts
+++ b/src/hooks/use-triggers.ts
@@ -1,6 +1,7 @@
 'use client';
 import { useEffect, useState } from 'react';
 import { getAuthToken } from '@/lib/auth';
+import { mockTriggers } from '@/data/mock-triggers';
 
 export function useTriggers(appKey?: string) {
   const [triggers, setTriggers] = useState<any[] | null>(null);
@@ -25,6 +26,7 @@ export function useTriggers(appKey?: string) {
         const json = await res.json();
         setTriggers(json.data);
       } catch (err) {
+        setTriggers(mockTriggers[appKey] || []);
         setError(err as Error);
       } finally {
         setIsLoading(false);


### PR DESCRIPTION
## Summary
- add mock triggers data
- fallback to mock triggers in `useTriggers`

## Testing
- `npm run lint`
- `cd automat/packages/backend && yarn test` *(fails: Test environment file not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f982ddd488329b4d47294418008f9