### PR TITLE
Refactor node detail types

### DIFF
--- a/src/components/nodes/node-details/types.ts
+++ b/src/components/nodes/node-details/types.ts
@@ -1,4 +1,4 @@
-import type { AppNode } from '@/components/nodes';
+import type { AppNode, WorkflowNodeData } from '@/components/nodes';
 
 export type ActionType = 'shopify' | 'logical';
 
@@ -14,21 +14,7 @@ export interface ActionCategory {
 }
 
 export type NodeDetailProps = {
-    node: AppNode;
-    setNodeData: (nodeId: string, newData: Partial<any>) => void;
-  };
+  node: AppNode;
+  setNodeData: (nodeId: string, newData: Partial<WorkflowNodeData>) => void;
+};
 
-// src/components/nodes/types.ts
-export type WorkflowNodeData = {
-    title: string;
-    platform?: string;
-    event?: string;
-    actionType?: string;  // <-- add this if not already present
-    listingId?: string;
-    quantity?: number;
-    /**
-     * Key of the application selected for this action node.
-     */
-    appKey?: string;
-  };
-  


### PR DESCRIPTION
## Summary
- rely on shared `WorkflowNodeData` type
- remove redundant type definition in `node-details`

## Testing
- `npm run lint`
- `yarn test` *(fails: Cannot find package 'pg')*

------
https://chatgpt.com/codex/tasks/task_e_684fb542d8908329a96d0700b8314811