### PR TITLE
Add SPDX license identifiers

### DIFF
--- a/automat/packages/backend/package.json
+++ b/automat/packages/backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@automatisch/backend",
   "version": "0.10.0",
-  "license": "See LICENSE file",
+  "license": "AGPL-3.0-only",
   "description": "The open source Zapier alternative. Build workflow automation without spending time and money.",
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -51,5 +51,6 @@
     "tailwindcss": "^4.1.4",
     "typescript": "^5",
     "vitest": "^3.2.3"
-  }
+  },
+  "license": "AGPL-3.0-only"
 }


### PR DESCRIPTION
## Summary
- add AGPL-3.0-only license field to root `package.json`
- use AGPL-3.0-only license in backend `package.json`

## Testing
- `npm run lint`
- `yarn test` in `automat/packages/backend` *(fails: Test environment file (.env.test) not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fb543609083299f5e948f82f7b98d