### PR TITLE
Fix dynamic API routes and clean Etsy handler

### DIFF
--- a/src/app/api/apps/[appKey]/actions/route.ts
+++ b/src/app/api/apps/[appKey]/actions/route.ts
@@ -6,7 +6,7 @@ export async function GET(
   request: NextRequest,
   { params }: { params: { appKey: string } }
 ) {
-  const { appKey } = params;
+  const { appKey } = await params;
   const token = request.headers.get('authorization');
   try {
     const url = `${backendUrl}/internal/api/v1/apps/${appKey}/actions`;

--- a/src/app/api/apps/[appKey]/triggers/route.ts
+++ b/src/app/api/apps/[appKey]/triggers/route.ts
@@ -6,7 +6,7 @@ export async function GET(
   request: NextRequest,
   { params }: { params: { appKey: string } }
 ) {
-  const { appKey } = params;
+  const { appKey } = await params;
   const token = request.headers.get('authorization');
   try {
     const url = `${backendUrl}/internal/api/v1/apps/${appKey}/triggers`;


### PR DESCRIPTION
## Summary
- remove unused Etsy API route
- await params in dynamic route handlers so Next.js API routes don't crash

## Testing
- `npm run lint`
- `yarn test` *(fails: Cannot find package 'pg')*

------
https://chatgpt.com/codex/tasks/task_e_684f9d9299cc83299d45c36a2e18e2c1