### PR TITLE
Clarify backend prerequisites in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ To get started, follow these steps:
    # Or run the Node server directly
    node packages/backend/src/server.js
    ```
+  Running `node packages/backend/src/server.js` requires PostgreSQL and Redis to be running and properly configured. `docker-compose up` starts these services automatically.
 
 3. **Run the development server**:
 


### PR DESCRIPTION
## Summary
- update README instructions for starting the backend

## Testing
- `npm run lint`
- `yarn test` *(fails: Test environment file `.env.test` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68507902618883299a9561f0bddcf12e