### PR TITLE
Dynamic fields for action nodes

### DIFF
--- a/src/app/api/apps/[appKey]/actions/[actionKey]/route.ts
+++ b/src/app/api/apps/[appKey]/actions/[actionKey]/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const backendUrl = process.env.BACKEND_URL || 'http://localhost:3000';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { appKey: string; actionKey: string } }
+) {
+  const { appKey, actionKey } = params;
+  const token = request.headers.get('authorization');
+  try {
+    const url = `${backendUrl}/internal/api/v1/apps/${appKey}/actions/${actionKey}/substeps`;
+    const headers: HeadersInit = {};
+    if (token) {
+      headers['Authorization'] = token;
+    }
+    const res = await fetch(url, { headers });
+
+    return new NextResponse(res.body, {
+      status: res.status,
+      headers: res.headers,
+    });
+  } catch (error: any) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}

--- a/src/components/nodes/action-node.tsx
+++ b/src/components/nodes/action-node.tsx
@@ -13,9 +13,11 @@ import {
     useNodeId,
     XYPosition,
   } from '@xyflow/react';
+import { useActionFields } from '@/hooks/use-action-fields';
 export function ActionNode({ id, data, type }: WorkflowNodeProps) {
 
   const nodeRef = useRef<HTMLDivElement>(null);
+  const { fields } = useActionFields(data.appKey, data.actionType);
 
   return (
     <WorkflowNode id={id} data={data} type={type} nodeRef={nodeRef}>
@@ -35,7 +37,14 @@ export function ActionNode({ id, data, type }: WorkflowNodeProps) {
         <p className="mt-1">
           Selected App: <strong>{data.appKey || 'None'}</strong>
         </p>
-
+        {fields?.map((f) => {
+          const val = (data as any)[f.key];
+          return val ? (
+            <p key={f.key} className="mt-1">
+              {f.label}: <strong>{String(val)}</strong>
+            </p>
+          ) : null;
+        })}
       </div>
 
       {/* <AppHandle

--- a/src/components/nodes/node-details/action-node-detail.tsx
+++ b/src/components/nodes/node-details/action-node-detail.tsx
@@ -1,22 +1,22 @@
 'use client';
 import React, { useState } from 'react';
-import { useAppStore } from '@/store';
 import { useApps } from '@/hooks/use-apps';
 import { useActions } from '@/hooks/use-actions';
+import { useActionFields } from '@/hooks/use-action-fields';
 import type { NodeDetailProps, Action } from './types';
 
-export const ActionNodeDetail = ({ node }: NodeDetailProps) => {
-  const setNodeData = useAppStore((state) => state.setNodeData);
+export const ActionNodeDetail = ({ node, setNodeData }: NodeDetailProps) => {
   const { apps } = useApps();
   const [selectedApp, setSelectedApp] = useState<string | null>(
     node.data.appKey ?? null,
   );
-  const { actions } = useActions(selectedApp ?? undefined);
   const [selectedAction, setSelectedAction] = useState<Action | null>(
     node.data.actionType
       ? { id: node.data.actionType, title: node.data.title ?? '' }
       : null,
   );
+  const { actions } = useActions(selectedApp ?? undefined);
+  const { fields } = useActionFields(selectedApp ?? undefined, selectedAction?.id);
 
   const handleAppSelect = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const appKey = e.target.value;
@@ -84,6 +84,46 @@ export const ActionNodeDetail = ({ node }: NodeDetailProps) => {
               </option>
             ))}
           </select>
+        </div>
+      )}
+
+      {fields && fields.length > 0 && (
+        <div className="flex flex-col gap-4">
+          {fields.map((field) => (
+            <div key={field.key} className="flex flex-col gap-1">
+              <label className="font-semibold mb-1" htmlFor={field.key}>
+                {field.label}
+              </label>
+              {field.type === 'dropdown' && field.options ? (
+                <select
+                  id={field.key}
+                  className="border rounded p-2 w-full"
+                  value={(node.data as any)[field.key] || ''}
+                  onChange={(e) =>
+                    setNodeData(node.id, { [field.key]: e.target.value })
+                  }
+                >
+                  <option value="" disabled>
+                    Select {field.label.toLowerCase()}
+                  </option>
+                  {field.options.map((opt) => (
+                    <option key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </option>
+                  ))}
+                </select>
+              ) : (
+                <input
+                  id={field.key}
+                  className="border rounded p-2 w-full"
+                  value={(node.data as any)[field.key] || ''}
+                  onChange={(e) =>
+                    setNodeData(node.id, { [field.key]: e.target.value })
+                  }
+                />
+              )}
+            </div>
+          ))}
         </div>
       )}
     </div>

--- a/src/hooks/use-action-fields.ts
+++ b/src/hooks/use-action-fields.ts
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react';
+import { getAuthToken } from '@/lib/auth';
+
+export interface ActionFieldOption {
+  label: string;
+  value: string;
+}
+
+export interface ActionField {
+  label: string;
+  key: string;
+  type: string;
+  required?: boolean;
+  description?: string;
+  options?: ActionFieldOption[];
+}
+
+export function useActionFields(appKey?: string, actionKey?: string) {
+  const [fields, setFields] = useState<ActionField[] | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    if (!appKey || !actionKey) return;
+
+    const fetchFields = async () => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const headers: HeadersInit = {};
+        const token = getAuthToken();
+        if (token) headers['Authorization'] = token;
+        const res = await fetch(`/api/apps/${appKey}/actions/${actionKey}` , { headers });
+        if (!res.ok) throw new Error('Failed to fetch action fields');
+        const json = await res.json();
+        setFields(json.data);
+      } catch (err) {
+        setError(err as Error);
+        setFields(null);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchFields();
+  }, [appKey, actionKey]);
+
+  return { fields, isLoading, error };
+}

--- a/src/store/__tests__/set-node-data.test.ts
+++ b/src/store/__tests__/set-node-data.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { createAppStore, defaultState } from '../app-store';
+import { createNodeByType } from '@/components/nodes';
+
+describe('setNodeData', () => {
+  it('updates node parameters', () => {
+    const node = createNodeByType({ type: 'action-node', id: 'A', position: { x: 0, y: 0 } });
+    const store = createAppStore({ ...defaultState, nodes: [node], edges: [] });
+
+    store.getState().setNodeData('A', { appKey: 'gmail', actionType: 'sendEmail' });
+
+    const updated = store.getState().nodes.find(n => n.id === 'A');
+    expect(updated?.data.appKey).toBe('gmail');
+    expect(updated?.data.actionType).toBe('sendEmail');
+  });
+});


### PR DESCRIPTION
## Summary
- fetch action metadata from backend
- show field inputs for selected action
- display selected field values in action node preview
- expose API route for action metadata
- test setNodeData logic

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot find package 'axios'...)*
- `yarn test` in backend *(fails: Cannot find package 'pg')*

------
https://chatgpt.com/codex/tasks/task_e_6851c4e2d9108329a72908929d6d1820