### PR TITLE
Add connections hook and API route

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,14 @@ BACKEND_URL=http://localhost:3000
 DEEPSEEK_API_KEY=your-deepseek-api-key
 ```
 
+
 The `DEEPSEEK_API_KEY` is required for the AI Workflow Generator node.
+
+## API Routes
+
+These routes proxy requests to the backend using the `BACKEND_URL` value:
+
+- `GET /api/apps/[appKey]/connections` – list connections for a given app.
 
 ## Tech Stack
 

--- a/src/app/api/apps/[appKey]/connections/route.ts
+++ b/src/app/api/apps/[appKey]/connections/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const backendUrl = process.env.BACKEND_URL || 'http://localhost:3000';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { appKey: string } }
+) {
+  const { appKey } = await params;
+  const token = request.headers.get('authorization');
+  try {
+    const url = `${backendUrl}/internal/api/v1/apps/${appKey}/connections`;
+    const headers: HeadersInit = {};
+    if (token) {
+      headers['Authorization'] = token;
+    }
+    const res = await fetch(url, { headers });
+
+    return new NextResponse(res.body, {
+      status: res.status,
+      headers: res.headers,
+    });
+  } catch (error: any) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}

--- a/src/hooks/use-connections.ts
+++ b/src/hooks/use-connections.ts
@@ -1,0 +1,40 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { getAuthToken } from '@/lib/auth';
+
+export function useConnections(appKey?: string) {
+  const [connections, setConnections] = useState<any[] | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    if (!appKey) return;
+
+    const fetchConnections = async () => {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const headers: HeadersInit = {};
+        const token = getAuthToken();
+        if (token) {
+          headers['Authorization'] = token;
+        }
+        const res = await fetch(`/api/apps/${appKey}/connections`, { headers });
+        if (!res.ok) throw new Error('Failed to fetch connections');
+        const json = await res.json();
+        setConnections(json.data);
+      } catch (err) {
+        setConnections(null);
+        setError(err as Error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchConnections();
+  }, [appKey]);
+
+  return { connections, isLoading, error };
+}
+


### PR DESCRIPTION
## Summary
- add `/api/apps/[appKey]/connections` route
- add `useConnections` hook for fetching connection data
- document the new API route in README

## Testing
- `npm run lint`
- `cd automat/packages/backend && yarn test` *(fails: Cannot find package 'pg')*

------
https://chatgpt.com/codex/tasks/task_e_6851c4d7e0408329a2efb0d782c0ff1f