### PR TITLE
Add Connection interface for useConnections hook

### DIFF
--- a/src/hooks/use-connections.ts
+++ b/src/hooks/use-connections.ts
@@ -2,8 +2,17 @@
 import { useEffect, useState } from 'react';
 import { getAuthToken } from '@/lib/auth';
 
-export function useConnections(appKey?: string) {
-  const [connections, setConnections] = useState<any[] | null>(null);
+export interface Connection {
+  id: string;
+  name: string;
+}
+
+export function useConnections(appKey?: string): {
+  connections: Connection[] | null;
+  isLoading: boolean;
+  error: Error | null;
+} {
+  const [connections, setConnections] = useState<Connection[] | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
 


### PR DESCRIPTION
## Summary
- add `Connection` interface and use it in `useConnections`
- update return type for `useConnections`

## Testing
- `npm run lint`
- `yarn test` (fails: Cannot find package 'pg')

------
https://chatgpt.com/codex/tasks/task_e_6851ca32f76083298953169a83ea386e