### PR TITLE
Fix appKey param extraction

### DIFF
--- a/src/app/api/apps/[appKey]/actions/route.ts
+++ b/src/app/api/apps/[appKey]/actions/route.ts
@@ -6,7 +6,7 @@ export async function GET(
   request: NextRequest,
   { params }: { params: { appKey: string } }
 ) {
-  const { appKey } = await params;
+  const { appKey } = params;
   const token = request.headers.get('authorization');
   try {
     const url = `${backendUrl}/internal/api/v1/apps/${appKey}/actions`;

--- a/src/app/api/apps/[appKey]/connections/route.ts
+++ b/src/app/api/apps/[appKey]/connections/route.ts
@@ -6,7 +6,7 @@ export async function GET(
   request: NextRequest,
   { params }: { params: { appKey: string } }
 ) {
-  const { appKey } = await params;
+  const { appKey } = params;
   const token = request.headers.get('authorization');
   try {
     const url = `${backendUrl}/internal/api/v1/apps/${appKey}/connections`;


### PR DESCRIPTION
## Summary
- fix `appKey` extraction in actions and connections routes

## Testing
- `npm run lint`
- `yarn test` *(fails: Cannot find package 'pg')*

------
https://chatgpt.com/codex/tasks/task_e_6851ca319b2883298eed068006ee3f2d