### PR TITLE
Add connection selection for action nodes

### DIFF
--- a/src/components/nodes/action-node.tsx
+++ b/src/components/nodes/action-node.tsx
@@ -37,6 +37,11 @@ export function ActionNode({ id, data, type }: WorkflowNodeProps) {
         <p className="mt-1">
           Selected App: <strong>{data.appKey || 'None'}</strong>
         </p>
+        {data.connectionId && (
+          <p className="mt-1">
+            Connection: <strong>{data.connectionId}</strong>
+          </p>
+        )}
         {fields?.map((f) => {
           const val = (data as any)[f.key];
           return val ? (

--- a/src/components/nodes/index.tsx
+++ b/src/components/nodes/index.tsx
@@ -39,6 +39,10 @@ export type WorkflowNodeData = {
    * action is chosen in the side panel and displayed within the node.
    */
   appKey?: string;
+  /**
+   * ID of the connection to use for the selected action.
+   */
+  connectionId?: string;
 };
 
 export type WorkflowNodeProps = NodeProps<Node<WorkflowNodeData>> & {
@@ -248,6 +252,7 @@ const nodesConfig: Record<AppNodeType, NodeConfig> = {
     dataDefaults: {
       title: 'Action',
       actionType: '',
+      connectionId: '',
     },
   },
   'ai-node': {

--- a/src/components/nodes/node-details/action-node-detail.tsx
+++ b/src/components/nodes/node-details/action-node-detail.tsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import { useApps } from '@/hooks/use-apps';
 import { useActions } from '@/hooks/use-actions';
 import { useActionFields } from '@/hooks/use-action-fields';
+import { useConnections } from '@/hooks/use-connections';
 import type { NodeDetailProps, Action } from './types';
 
 export const ActionNodeDetail = ({ node, setNodeData }: NodeDetailProps) => {
@@ -15,14 +16,19 @@ export const ActionNodeDetail = ({ node, setNodeData }: NodeDetailProps) => {
       ? { id: node.data.actionType, title: node.data.title ?? '' }
       : null,
   );
+  const [selectedConnection, setSelectedConnection] = useState<string | null>(
+    node.data.connectionId ?? null,
+  );
   const { actions } = useActions(selectedApp ?? undefined);
   const { fields } = useActionFields(selectedApp ?? undefined, selectedAction?.id);
+  const { connections } = useConnections(selectedApp ?? undefined);
 
   const handleAppSelect = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const appKey = e.target.value;
     setSelectedApp(appKey);
     setSelectedAction(null);
-    setNodeData(node.id, { appKey, actionType: undefined });
+    setSelectedConnection(null);
+    setNodeData(node.id, { appKey, actionType: undefined, connectionId: undefined });
   };
 
   const handleActionSelect = (e: React.ChangeEvent<HTMLSelectElement>) => {
@@ -33,6 +39,15 @@ export const ActionNodeDetail = ({ node, setNodeData }: NodeDetailProps) => {
       appKey: selectedApp ?? undefined,
       actionType: actionKey,
       title: action?.title,
+    });
+  };
+
+  const handleConnectionSelect = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const connectionKey = e.target.value;
+    setSelectedConnection(connectionKey);
+    setNodeData(node.id, {
+      appKey: selectedApp ?? undefined,
+      connectionId: connectionKey,
     });
   };
 
@@ -81,6 +96,29 @@ export const ActionNodeDetail = ({ node, setNodeData }: NodeDetailProps) => {
             {mappedActions.map((action) => (
               <option key={action.id} value={action.id}>
                 {action.title}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      {selectedApp && connections && (
+        <div>
+          <label className="font-semibold mb-1 block" htmlFor="connection-select">
+            Connection
+          </label>
+          <select
+            id="connection-select"
+            className="border rounded p-2 w-full"
+            value={selectedConnection || ''}
+            onChange={handleConnectionSelect}
+          >
+            <option value="" disabled>
+              Select connection
+            </option>
+            {connections.map((connection) => (
+              <option key={connection.id} value={connection.id}>
+                {connection.name}
               </option>
             ))}
           </select>

--- a/src/config/node-registry.ts
+++ b/src/config/node-registry.ts
@@ -48,7 +48,7 @@ export const nodeRegistry: Record<NodeType, NodeRegistryItem> = {
 
     ],
     detailComponent: ActionNodeDetail,
-    dataDefaults: { actionType: '', title: 'Action' },
+    dataDefaults: { actionType: '', title: 'Action', connectionId: '' },
   },
   'inventory-node': {
     id: 'inventory-node',


### PR DESCRIPTION
## Summary
- fetch app connections with `useConnections`
- allow selecting a connection in `ActionNodeDetail`
- persist connection ID in workflow node data
- display connection ID inside action node preview

## Testing
- `npm run lint`
- `yarn test` *(fails: Cannot find package 'pg')*

------
https://chatgpt.com/codex/tasks/task_e_6851cfd20554832981b12aa35e1b3db6