### PR TITLE
Verify connection persistence

### DIFF
--- a/src/store/__tests__/set-node-data.test.ts
+++ b/src/store/__tests__/set-node-data.test.ts
@@ -13,4 +13,14 @@ describe('setNodeData', () => {
     expect(updated?.data.appKey).toBe('gmail');
     expect(updated?.data.actionType).toBe('sendEmail');
   });
+
+  it('persists connection id', () => {
+    const node = createNodeByType({ type: 'action-node', id: 'B', position: { x: 0, y: 0 } });
+    const store = createAppStore({ ...defaultState, nodes: [node], edges: [] });
+
+    store.getState().setNodeData('B', { connectionId: '123' });
+
+    const updated = store.getState().nodes.find(n => n.id === 'B');
+    expect(updated?.data.connectionId).toBe('123');
+  });
 });


### PR DESCRIPTION
## Summary
- ensure connection id persists on node data when updating
- add regression test for node data persistence

## Testing
- `npm run lint`
- `yarn test` *(fails: Test environment file (.env.test) not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851d333eb5483298dfb11b2894b32e5