### PR TITLE
Add connection selection to action node

### DIFF
--- a/src/app/api/apps/[appKey]/connections/route.ts
+++ b/src/app/api/apps/[appKey]/connections/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const backendUrl = process.env.BACKEND_URL || 'http://localhost:3000';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { appKey: string } },
+) {
+  const { appKey } = await params;
+  const token = request.headers.get('authorization');
+  try {
+    const url = `${backendUrl}/internal/api/v1/apps/${appKey}/connections`;
+    const headers: HeadersInit = {};
+    if (token) {
+      headers['Authorization'] = token;
+    }
+    const res = await fetch(url, { headers });
+
+    return new NextResponse(res.body, {
+      status: res.status,
+      headers: res.headers,
+    });
+  } catch (error: any) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}

--- a/src/components/nodes/index.tsx
+++ b/src/components/nodes/index.tsx
@@ -39,6 +39,10 @@ export type WorkflowNodeData = {
    * action is chosen in the side panel and displayed within the node.
    */
   appKey?: string;
+  /**
+   * Identifier of the connection to use when executing the action.
+   */
+  connectionId?: string;
 };
 
 export type WorkflowNodeProps = NodeProps<Node<WorkflowNodeData>> & {
@@ -248,6 +252,7 @@ const nodesConfig: Record<AppNodeType, NodeConfig> = {
     dataDefaults: {
       title: 'Action',
       actionType: '',
+      connectionId: '',
     },
   },
   'ai-node': {

--- a/src/components/nodes/node-details/action-node-detail.tsx
+++ b/src/components/nodes/node-details/action-node-detail.tsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import { useAppStore } from '@/store';
 import { useApps } from '@/hooks/use-apps';
 import { useActions } from '@/hooks/use-actions';
+import { useConnections } from '@/hooks/use-connections';
 import type { NodeDetailProps, Action } from './types';
 
 export const ActionNodeDetail = ({ node }: NodeDetailProps) => {
@@ -12,17 +13,35 @@ export const ActionNodeDetail = ({ node }: NodeDetailProps) => {
     node.data.appKey ?? null,
   );
   const { actions } = useActions(selectedApp ?? undefined);
+  const { connections } = useConnections(selectedApp ?? undefined);
   const [selectedAction, setSelectedAction] = useState<Action | null>(
     node.data.actionType
       ? { id: node.data.actionType, title: node.data.title ?? '' }
       : null,
+  );
+  const [selectedConnection, setSelectedConnection] = useState<string | null>(
+    node.data.connectionId ?? null,
   );
 
   const handleAppSelect = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const appKey = e.target.value;
     setSelectedApp(appKey);
     setSelectedAction(null);
-    setNodeData(node.id, { appKey, actionType: undefined });
+    setSelectedConnection(null);
+    setNodeData(node.id, {
+      appKey,
+      actionType: undefined,
+      connectionId: undefined,
+    });
+  };
+
+  const handleConnectionSelect = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const connId = e.target.value;
+    setSelectedConnection(connId);
+    setNodeData(node.id, {
+      appKey: selectedApp ?? undefined,
+      connectionId: connId,
+    });
   };
 
   const handleActionSelect = (e: React.ChangeEvent<HTMLSelectElement>) => {
@@ -33,6 +52,7 @@ export const ActionNodeDetail = ({ node }: NodeDetailProps) => {
       appKey: selectedApp ?? undefined,
       actionType: actionKey,
       title: action?.title,
+      connectionId: selectedConnection ?? undefined,
     });
   };
 
@@ -65,26 +85,49 @@ export const ActionNodeDetail = ({ node }: NodeDetailProps) => {
       </div>
 
       {selectedApp && (
-        <div>
-          <label className="font-semibold mb-1 block" htmlFor="action-select">
-            Choose Action
-          </label>
-          <select
-            id="action-select"
-            className="border rounded p-2 w-full"
-            value={selectedAction?.id || ''}
-            onChange={handleActionSelect}
-          >
-            <option value="" disabled>
-              Select action
-            </option>
-            {mappedActions.map((action) => (
-              <option key={action.id} value={action.id}>
-                {action.title}
+        <>
+          <div>
+            <label className="font-semibold mb-1 block" htmlFor="connection-select">
+              Connection
+            </label>
+            <select
+              id="connection-select"
+              className="border rounded p-2 w-full"
+              value={selectedConnection || ''}
+              onChange={handleConnectionSelect}
+            >
+              <option value="" disabled>
+                Select connection
               </option>
-            ))}
-          </select>
-        </div>
+              {(connections || []).map((c: any) => (
+                <option key={c.id} value={c.id}>
+                  {c.name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label className="font-semibold mb-1 block" htmlFor="action-select">
+              Choose Action
+            </label>
+            <select
+              id="action-select"
+              className="border rounded p-2 w-full"
+              value={selectedAction?.id || ''}
+              onChange={handleActionSelect}
+            >
+              <option value="" disabled>
+                Select action
+              </option>
+              {mappedActions.map((action) => (
+                <option key={action.id} value={action.id}>
+                  {action.title}
+                </option>
+              ))}
+            </select>
+          </div>
+        </>
       )}
     </div>
   );

--- a/src/config/node-registry.ts
+++ b/src/config/node-registry.ts
@@ -48,7 +48,7 @@ export const nodeRegistry: Record<NodeType, NodeRegistryItem> = {
 
     ],
     detailComponent: ActionNodeDetail,
-    dataDefaults: { actionType: '', title: 'Action' },
+    dataDefaults: { actionType: '', title: 'Action', connectionId: '' },
   },
   'inventory-node': {
     id: 'inventory-node',

--- a/src/data/mock-connections.ts
+++ b/src/data/mock-connections.ts
@@ -1,0 +1,14 @@
+export const mockConnections: Record<string, { id: string; name: string }[]> = {
+  gmail: [
+    { id: 'gmail-1', name: 'Gmail Account' },
+  ],
+  slack: [
+    { id: 'slack-1', name: 'Slack Workspace' },
+  ],
+  github: [
+    { id: 'github-1', name: 'GitHub Account' },
+  ],
+  notion: [
+    { id: 'notion-1', name: 'Notion Workspace' },
+  ],
+};

--- a/src/hooks/use-connections.ts
+++ b/src/hooks/use-connections.ts
@@ -1,0 +1,39 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { getAuthToken } from '@/lib/auth';
+import { mockConnections } from '@/data/mock-connections';
+
+export function useConnections(appKey?: string) {
+  const [connections, setConnections] = useState<any[] | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    if (!appKey) return;
+
+    const fetchConnections = async () => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const headers: HeadersInit = {};
+        const token = getAuthToken();
+        if (token) {
+          headers['Authorization'] = token;
+        }
+        const res = await fetch(`/api/apps/${appKey}/connections`, { headers });
+        if (!res.ok) throw new Error('Failed to fetch connections');
+        const json = await res.json();
+        setConnections(json.data);
+      } catch (err) {
+        setConnections(mockConnections[appKey] || []);
+        setError(err as Error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchConnections();
+  }, [appKey]);
+
+  return { connections, isLoading, error };
+}


### PR DESCRIPTION
## Summary
- fetch connections for apps via new hook
- expose connection API route
- track connectionId in node data
- allow selecting connection in ActionNodeDetail
- include mock connection data
- add connectionId default in node config

## Testing
- `npm run lint`
- `yarn test` *(fails: Requires running Redis and PostgreSQL)*

------
https://chatgpt.com/codex/tasks/task_e_6851c6862ca48329860c80ee1296e6c0