### PR TITLE
Fix dynamic API route params

### DIFF
--- a/src/app/api/apps/[appKey]/actions/[actionKey]/route.ts
+++ b/src/app/api/apps/[appKey]/actions/[actionKey]/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+export const dynamic = 'force-dynamic';
+
 const backendUrl = process.env.BACKEND_URL || 'http://localhost:3000';
 
 export async function GET(

--- a/src/app/api/apps/[appKey]/actions/route.ts
+++ b/src/app/api/apps/[appKey]/actions/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+export const dynamic = 'force-dynamic';
+
 const backendUrl = process.env.BACKEND_URL || 'http://localhost:3000';
 
 export async function GET(

--- a/src/app/api/apps/[appKey]/connections/route.ts
+++ b/src/app/api/apps/[appKey]/connections/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+export const dynamic = 'force-dynamic';
+
 const backendUrl = process.env.BACKEND_URL || 'http://localhost:3000';
 
 export async function GET(

--- a/src/app/api/apps/[appKey]/triggers/route.ts
+++ b/src/app/api/apps/[appKey]/triggers/route.ts
@@ -1,12 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+export const dynamic = 'force-dynamic';
+
 const backendUrl = process.env.BACKEND_URL || 'http://localhost:3000';
 
 export async function GET(
   request: NextRequest,
   { params }: { params: { appKey: string } }
 ) {
-  const { appKey } = await params;
+  const { appKey } = params;
   const token = request.headers.get('authorization');
   try {
     const url = `${backendUrl}/internal/api/v1/apps/${appKey}/triggers`;


### PR DESCRIPTION
## Summary
- mark dynamic API routes as `force-dynamic`
- remove erroneous `await` in triggers route

## Testing
- `npm run lint`
- `yarn test` *(fails: Cannot find package 'pg')*

------
https://chatgpt.com/codex/tasks/task_e_6851d97c94d483298a31bdc8b1769a7a