### PR TITLE
Add dynamic field support for action nodes

### DIFF
--- a/src/components/nodes/action-node.tsx
+++ b/src/components/nodes/action-node.tsx
@@ -44,11 +44,19 @@ export function ActionNode({ id, data, type }: WorkflowNodeProps) {
         )}
         {fields?.map((f) => {
           const val = (data as any)[f.key];
-          return val ? (
+          if (!val) return null;
+          if (f.type === 'dynamic' && Array.isArray(val)) {
+            return (
+              <p key={f.key} className="mt-1">
+                {f.label}: <strong>{val.map((v: any) => Object.values(v).join(', ')).join('; ')}</strong>
+              </p>
+            );
+          }
+          return (
             <p key={f.key} className="mt-1">
               {f.label}: <strong>{String(val)}</strong>
             </p>
-          ) : null;
+          );
         })}
       </div>
 

--- a/src/components/nodes/node-details/action-node-detail.tsx
+++ b/src/components/nodes/node-details/action-node-detail.tsx
@@ -150,6 +150,62 @@ export const ActionNodeDetail = ({ node, setNodeData }: NodeDetailProps) => {
                     </option>
                   ))}
                 </select>
+              ) : field.type === 'dynamic' && field.fields ? (
+                <div className="flex flex-col gap-2">
+                  {((node.data as any)[field.key] || []).map(
+                    (entry: Record<string, string>, idx: number) => (
+                      <div key={idx} className="flex items-center gap-2">
+                        {field.fields!.map((sub) => (
+                          <input
+                            key={sub.key}
+                            id={`${field.key}-${idx}-${sub.key}`}
+                            className="border rounded p-2 w-full"
+                            value={entry[sub.key] || ''}
+                            onChange={(e) => {
+                              const arr = [
+                                ...((node.data as any)[field.key] || []),
+                              ];
+                              arr[idx] = {
+                                ...arr[idx],
+                                [sub.key]: e.target.value,
+                              };
+                              setNodeData(node.id, { [field.key]: arr });
+                            }}
+                          />
+                        ))}
+                        <button
+                          type="button"
+                          className="text-xs px-2 py-1 border rounded"
+                          onClick={() => {
+                            const arr = [
+                              ...((node.data as any)[field.key] || []),
+                            ];
+                            arr.splice(idx, 1);
+                            setNodeData(node.id, { [field.key]: arr });
+                          }}
+                        >
+                          Remove
+                        </button>
+                      </div>
+                    ),
+                  )}
+                  <button
+                    type="button"
+                    className="text-xs px-2 py-1 border rounded self-start"
+                    onClick={() => {
+                      const arr = [
+                        ...((node.data as any)[field.key] || []),
+                        field.fields!.reduce(
+                          (acc, cur) => ({ ...acc, [cur.key]: '' }),
+                          {},
+                        ),
+                      ];
+                      setNodeData(node.id, { [field.key]: arr });
+                    }}
+                  >
+                    Add {field.label}
+                  </button>
+                </div>
               ) : (
                 <input
                   id={field.key}

--- a/src/hooks/use-action-fields.ts
+++ b/src/hooks/use-action-fields.ts
@@ -13,6 +13,10 @@ export interface ActionField {
   required?: boolean;
   description?: string;
   options?: ActionFieldOption[];
+  /**
+   * Nested fields for `dynamic` field types.
+   */
+  fields?: ActionField[];
 }
 
 export function useActionFields(appKey?: string, actionKey?: string) {


### PR DESCRIPTION
## Summary
- support nested `fields` info from backend
- render dynamic fields in the action node side panel
- display dynamic field values on action nodes

## Testing
- `npm run lint`
- `yarn test` *(fails: Cannot find package 'pg')*

------
https://chatgpt.com/codex/tasks/task_e_6851de3422208329bbfe15e085a42d14