### PR TITLE
Add dynamic fields fallback for Gmail action

### DIFF
--- a/src/components/nodes/action-node.tsx
+++ b/src/components/nodes/action-node.tsx
@@ -44,11 +44,19 @@ export function ActionNode({ id, data, type }: WorkflowNodeProps) {
         )}
         {fields?.map((f) => {
           const val = (data as any)[f.key];
-          return val ? (
+          if (!val) return null;
+          if (f.type === 'dynamic' && Array.isArray(val)) {
+            return (
+              <p key={f.key} className="mt-1">
+                {f.label}: <strong>{val.map((v: any) => Object.values(v).join(', ')).join('; ')}</strong>
+              </p>
+            );
+          }
+          return (
             <p key={f.key} className="mt-1">
               {f.label}: <strong>{String(val)}</strong>
             </p>
-          ) : null;
+          );
         })}
       </div>
 

--- a/src/components/nodes/node-details/action-node-detail.tsx
+++ b/src/components/nodes/node-details/action-node-detail.tsx
@@ -150,6 +150,62 @@ export const ActionNodeDetail = ({ node, setNodeData }: NodeDetailProps) => {
                     </option>
                   ))}
                 </select>
+              ) : field.type === 'dynamic' && field.fields ? (
+                <div className="flex flex-col gap-2">
+                  {((node.data as any)[field.key] || []).map(
+                    (entry: Record<string, string>, idx: number) => (
+                      <div key={idx} className="flex items-center gap-2">
+                        {field.fields!.map((sub) => (
+                          <input
+                            key={sub.key}
+                            id={`${field.key}-${idx}-${sub.key}`}
+                            className="border rounded p-2 w-full"
+                            value={entry[sub.key] || ''}
+                            onChange={(e) => {
+                              const arr = [
+                                ...((node.data as any)[field.key] || []),
+                              ];
+                              arr[idx] = {
+                                ...arr[idx],
+                                [sub.key]: e.target.value,
+                              };
+                              setNodeData(node.id, { [field.key]: arr });
+                            }}
+                          />
+                        ))}
+                        <button
+                          type="button"
+                          className="text-xs px-2 py-1 border rounded"
+                          onClick={() => {
+                            const arr = [
+                              ...((node.data as any)[field.key] || []),
+                            ];
+                            arr.splice(idx, 1);
+                            setNodeData(node.id, { [field.key]: arr });
+                          }}
+                        >
+                          Remove
+                        </button>
+                      </div>
+                    ),
+                  )}
+                  <button
+                    type="button"
+                    className="text-xs px-2 py-1 border rounded self-start"
+                    onClick={() => {
+                      const arr = [
+                        ...((node.data as any)[field.key] || []),
+                        field.fields!.reduce(
+                          (acc, cur) => ({ ...acc, [cur.key]: '' }),
+                          {},
+                        ),
+                      ];
+                      setNodeData(node.id, { [field.key]: arr });
+                    }}
+                  >
+                    Add {field.label}
+                  </button>
+                </div>
               ) : (
                 <input
                   id={field.key}

--- a/src/data/mock-action-fields.ts
+++ b/src/data/mock-action-fields.ts
@@ -1,0 +1,74 @@
+import type { ActionField } from '@/hooks/use-action-fields';
+
+export const mockActionFields: Record<string, Record<string, ActionField[]>> = {
+  gmail: {
+    'send-email': [
+      {
+        label: 'TOs',
+        key: 'tos',
+        type: 'dynamic',
+        required: false,
+        description: '',
+        fields: [
+          { label: 'To', key: 'to', type: 'string', required: false },
+        ],
+      },
+      {
+        label: 'CCs',
+        key: 'ccs',
+        type: 'dynamic',
+        required: false,
+        description: '',
+        fields: [
+          { label: 'CC', key: 'cc', type: 'string', required: false },
+        ],
+      },
+      {
+        label: 'BCCs',
+        key: 'bccs',
+        type: 'dynamic',
+        required: false,
+        description: '',
+        fields: [
+          { label: 'BCC', key: 'bcc', type: 'string', required: false },
+        ],
+      },
+      {
+        label: 'From',
+        key: 'from',
+        type: 'dropdown',
+        required: false,
+        description:
+          'Select an email address or alias from your Gmail Account. Defaults to the primary email address.',
+        options: [],
+      },
+      { label: 'From Name', key: 'fromName', type: 'string', required: false },
+      {
+        label: 'Reply To',
+        key: 'replyTo',
+        type: 'string',
+        required: false,
+        description: 'Specify a single reply address other than your own.',
+      },
+      { label: 'Subject', key: 'subject', type: 'string', required: true },
+      {
+        label: 'Body Type',
+        key: 'bodyType',
+        type: 'dropdown',
+        required: false,
+        options: [
+          { label: 'plain', value: 'plain' },
+          { label: 'html', value: 'html' },
+        ],
+      },
+      { label: 'Body', key: 'emailBody', type: 'string', required: true },
+      {
+        label: 'Signature',
+        key: 'signature',
+        type: 'dropdown',
+        required: false,
+        options: [],
+      },
+    ],
+  },
+};

--- a/src/hooks/use-action-fields.ts
+++ b/src/hooks/use-action-fields.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { getAuthToken } from '@/lib/auth';
+import { mockActionFields } from '@/data/mock-action-fields';
 
 export interface ActionFieldOption {
   label: string;
@@ -13,6 +14,10 @@ export interface ActionField {
   required?: boolean;
   description?: string;
   options?: ActionFieldOption[];
+  /**
+   * Nested fields for `dynamic` field types.
+   */
+  fields?: ActionField[];
 }
 
 export function useActionFields(appKey?: string, actionKey?: string) {
@@ -35,8 +40,8 @@ export function useActionFields(appKey?: string, actionKey?: string) {
         const json = await res.json();
         setFields(json.data);
       } catch (err) {
+        setFields(mockActionFields[appKey]?.[actionKey] || null);
         setError(err as Error);
-        setFields(null);
       } finally {
         setIsLoading(false);
       }


### PR DESCRIPTION
## Summary
- provide mock action fields for Gmail's send-email action
- use mock action fields when backend fetch fails

## Testing
- `npm run lint`
- `yarn test` *(fails: Cannot find package 'pg')*

------
https://chatgpt.com/codex/tasks/task_e_6851de3422208329bbfe15e085a42d14