### PR TITLE
Add UI for Gmail send-email fields

### DIFF
--- a/src/components/nodes/action-node.tsx
+++ b/src/components/nodes/action-node.tsx
@@ -44,11 +44,23 @@ export function ActionNode({ id, data, type }: WorkflowNodeProps) {
         )}
         {fields?.map((f) => {
           const val = (data as any)[f.key];
-          return val ? (
+          if (!val) return null;
+          if (f.type === 'dynamic' && Array.isArray(val)) {
+            return (
+              <p key={f.key} className="mt-1">
+                {f.label}: <strong>{val.map((v: any) => Object.values(v).join(', ')).join('; ')}</strong>
+              </p>
+            );
+          }
+          let displayVal = String(val);
+          if (f.type === 'textarea') {
+            displayVal = displayVal.length > 30 ? displayVal.slice(0, 30) + '…' : displayVal;
+          }
+          return (
             <p key={f.key} className="mt-1">
-              {f.label}: <strong>{String(val)}</strong>
+              {f.label}: <strong>{displayVal}</strong>
             </p>
-          ) : null;
+          );
         })}
       </div>
 

--- a/src/components/nodes/node-details/action-node-detail.tsx
+++ b/src/components/nodes/node-details/action-node-detail.tsx
@@ -150,6 +150,71 @@ export const ActionNodeDetail = ({ node, setNodeData }: NodeDetailProps) => {
                     </option>
                   ))}
                 </select>
+              ) : field.type === 'textarea' ? (
+                <textarea
+                  id={field.key}
+                  className="border rounded p-2 w-full h-32"
+                  value={(node.data as any)[field.key] || ''}
+                  onChange={(e) =>
+                    setNodeData(node.id, { [field.key]: e.target.value })
+                  }
+                />
+              ) : field.type === 'dynamic' && field.fields ? (
+                <div className="flex flex-col gap-2">
+                  {((node.data as any)[field.key] || []).map(
+                    (entry: Record<string, string>, idx: number) => (
+                      <div key={idx} className="flex items-center gap-2">
+                        {field.fields!.map((sub) => (
+                          <input
+                            key={sub.key}
+                            id={`${field.key}-${idx}-${sub.key}`}
+                            className="border rounded p-2 w-full"
+                            value={entry[sub.key] || ''}
+                            onChange={(e) => {
+                              const arr = [
+                                ...((node.data as any)[field.key] || []),
+                              ];
+                              arr[idx] = {
+                                ...arr[idx],
+                                [sub.key]: e.target.value,
+                              };
+                              setNodeData(node.id, { [field.key]: arr });
+                            }}
+                          />
+                        ))}
+                        <button
+                          type="button"
+                          className="text-xs px-2 py-1 border rounded"
+                          onClick={() => {
+                            const arr = [
+                              ...((node.data as any)[field.key] || []),
+                            ];
+                            arr.splice(idx, 1);
+                            setNodeData(node.id, { [field.key]: arr });
+                          }}
+                        >
+                          Remove
+                        </button>
+                      </div>
+                    ),
+                  )}
+                  <button
+                    type="button"
+                    className="text-xs px-2 py-1 border rounded self-start"
+                    onClick={() => {
+                      const arr = [
+                        ...((node.data as any)[field.key] || []),
+                        field.fields!.reduce(
+                          (acc, cur) => ({ ...acc, [cur.key]: '' }),
+                          {},
+                        ),
+                      ];
+                      setNodeData(node.id, { [field.key]: arr });
+                    }}
+                  >
+                    Add {field.label}
+                  </button>
+                </div>
               ) : (
                 <input
                   id={field.key}

--- a/src/data/mock-action-fields.ts
+++ b/src/data/mock-action-fields.ts
@@ -1,0 +1,12 @@
+import type { ActionField } from '@/hooks/use-action-fields';
+
+export const mockActionFields: Record<string, Record<string, ActionField[]>> = {
+  gmail: {
+    'send-email': [
+      { label: 'From', key: 'from', type: 'string', required: true },
+      { label: 'To', key: 'to', type: 'string', required: true },
+      { label: 'Subject', key: 'subject', type: 'string', required: true },
+      { label: 'Message', key: 'message', type: 'textarea', required: true },
+    ],
+  },
+};

--- a/src/hooks/use-action-fields.ts
+++ b/src/hooks/use-action-fields.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { getAuthToken } from '@/lib/auth';
+import { mockActionFields } from '@/data/mock-action-fields';
 
 export interface ActionFieldOption {
   label: string;
@@ -13,6 +14,10 @@ export interface ActionField {
   required?: boolean;
   description?: string;
   options?: ActionFieldOption[];
+  /**
+   * Nested fields for `dynamic` field types.
+   */
+  fields?: ActionField[];
 }
 
 export function useActionFields(appKey?: string, actionKey?: string) {
@@ -35,8 +40,8 @@ export function useActionFields(appKey?: string, actionKey?: string) {
         const json = await res.json();
         setFields(json.data);
       } catch (err) {
+        setFields(mockActionFields[appKey]?.[actionKey] || null);
         setError(err as Error);
-        setFields(null);
       } finally {
         setIsLoading(false);
       }


### PR DESCRIPTION
## Summary
- shrink Gmail mock action fields to basic email info
- render textareas for "Message" fields
- handle textarea values in nodes

## Testing
- `npm run lint`
- `yarn test` *(fails: Cannot find package 'pg')*

------
https://chatgpt.com/codex/tasks/task_e_6851de3422208329bbfe15e085a42d14