### PR TITLE
Update action node to hide sensitive data

### DIFF
--- a/src/components/nodes/action-node.tsx
+++ b/src/components/nodes/action-node.tsx
@@ -42,22 +42,6 @@ export function ActionNode({ id, data, type }: WorkflowNodeProps) {
             Connection: <strong>{data.connectionId}</strong>
           </p>
         )}
-        {fields?.map((f) => {
-          const val = (data as any)[f.key];
-          if (!val) return null;
-          if (f.type === 'dynamic' && Array.isArray(val)) {
-            return (
-              <p key={f.key} className="mt-1">
-                {f.label}: <strong>{val.map((v: any) => Object.values(v).join(', ')).join('; ')}</strong>
-              </p>
-            );
-          }
-          return (
-            <p key={f.key} className="mt-1">
-              {f.label}: <strong>{String(val)}</strong>
-            </p>
-          );
-        })}
       </div>
 
       {/* <AppHandle

--- a/src/data/mock-action-fields.ts
+++ b/src/data/mock-action-fields.ts
@@ -33,6 +33,7 @@ export const mockActionFields: Record<string, Record<string, ActionField[]>> = {
           { label: 'BCC', key: 'bcc', type: 'string', required: false },
         ],
       },
+      { label: 'Body', key: 'emailBody', type: 'string', required: true },
       {
         label: 'From',
         key: 'from',
@@ -61,7 +62,6 @@ export const mockActionFields: Record<string, Record<string, ActionField[]>> = {
           { label: 'html', value: 'html' },
         ],
       },
-      { label: 'Body', key: 'emailBody', type: 'string', required: true },
       {
         label: 'Signature',
         key: 'signature',


### PR DESCRIPTION
## Summary
- hide action field values from the ActionNode display on the canvas
- move "Body" field underneath the CC/BCC fields

## Testing
- `npm run lint`
- `yarn test` *(fails: Cannot find package 'pg')*

------
https://chatgpt.com/codex/tasks/task_e_685318134250832995b3df60a27bfa29