### PR TITLE
Handle textarea fields for actions

### DIFF
--- a/src/components/nodes/node-details/action-node-detail.tsx
+++ b/src/components/nodes/node-details/action-node-detail.tsx
@@ -206,6 +206,16 @@ export const ActionNodeDetail = ({ node, setNodeData }: NodeDetailProps) => {
                     Add {field.label}
                   </button>
                 </div>
+              ) : field.type === 'textarea' ? (
+                <textarea
+                  id={field.key}
+                  className="border rounded p-2 w-full"
+                  rows={5}
+                  value={(node.data as any)[field.key] || ''}
+                  onChange={(e) =>
+                    setNodeData(node.id, { [field.key]: e.target.value })
+                  }
+                />
               ) : (
                 <input
                   id={field.key}

--- a/src/data/mock-action-fields.ts
+++ b/src/data/mock-action-fields.ts
@@ -33,7 +33,7 @@ export const mockActionFields: Record<string, Record<string, ActionField[]>> = {
           { label: 'BCC', key: 'bcc', type: 'string', required: false },
         ],
       },
-      { label: 'Body', key: 'emailBody', type: 'string', required: true },
+      { label: 'Body', key: 'emailBody', type: 'textarea', required: true },
       {
         label: 'From',
         key: 'from',

--- a/src/hooks/use-action-fields.ts
+++ b/src/hooks/use-action-fields.ts
@@ -10,7 +10,7 @@ export interface ActionFieldOption {
 export interface ActionField {
   label: string;
   key: string;
-  type: string;
+  type: 'string' | 'dropdown' | 'dynamic' | 'textarea';
   required?: boolean;
   description?: string;
   options?: ActionFieldOption[];


### PR DESCRIPTION
## Summary
- add `textarea` field type in action fields mock
- render `<textarea>` in ActionNodeDetail when needed
- include `textarea` in ActionField type definition

## Testing
- `npm run lint`
- `yarn test` *(fails: Cannot find package 'pg')*

------
https://chatgpt.com/codex/tasks/task_e_68531ab90eb0832986be3a2419076d57