### PR TITLE
Ensure dynamic fields show initial entry

### DIFF
--- a/src/components/nodes/node-details/action-node-detail.tsx
+++ b/src/components/nodes/node-details/action-node-detail.tsx
@@ -152,8 +152,16 @@ export const ActionNodeDetail = ({ node, setNodeData }: NodeDetailProps) => {
                 </select>
               ) : field.type === 'dynamic' && field.fields ? (
                 <div className="flex flex-col gap-2">
-                  {((node.data as any)[field.key] || []).map(
-                    (entry: Record<string, string>, idx: number) => (
+                  {(
+                    ((node.data as any)[field.key] || []).length > 0
+                      ? (node.data as any)[field.key]
+                      : [
+                          field.fields!.reduce(
+                            (acc, cur) => ({ ...acc, [cur.key]: '' }),
+                            {},
+                          ),
+                        ]
+                  ).map((entry: Record<string, string>, idx: number) => (
                       <div key={idx} className="flex items-center gap-2">
                         {field.fields!.map((sub) => (
                           <input


### PR DESCRIPTION
## Summary
- display an empty entry when a dynamic field is rendered
- keep the Add button for adding more entries

## Testing
- `npm run lint`
- `yarn test` *(fails: Test environment file `.env.test` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68531aba6948832987d39e78c50c8fbf