### PR TITLE
Sync selected node data

### DIFF
--- a/src/store/__tests__/set-node-data.test.ts
+++ b/src/store/__tests__/set-node-data.test.ts
@@ -23,4 +23,13 @@ describe('setNodeData', () => {
     const updated = store.getState().nodes.find(n => n.id === 'B');
     expect(updated?.data.connectionId).toBe('123');
   });
+
+  it('updates selected node', () => {
+    const node = createNodeByType({ type: 'action-node', id: 'C', position: { x: 0, y: 0 } });
+    const store = createAppStore({ ...defaultState, nodes: [node], edges: [], selectedNode: node });
+
+    store.getState().setNodeData('C', { appKey: 'slack' });
+
+    expect(store.getState().selectedNode?.data.appKey).toBe('slack');
+  });
 });

--- a/src/store/app-store.ts
+++ b/src/store/app-store.ts
@@ -143,13 +143,20 @@ export const createAppStore = (initialState: AppState = defaultState) => {
 
 
       setNodeData: (nodeId: string, newData: Partial<WorkflowNodeData>) => {
-        set((state) => ({
-          nodes: state.nodes.map((node) =>
+        set((state) => {
+          const nodes = state.nodes.map((node) =>
             node.id === nodeId
               ? { ...node, data: { ...node.data, ...newData } }
               : node
-          ),
-        }));
+          );
+
+          const selectedNode =
+            state.selectedNode?.id === nodeId
+              ? { ...state.selectedNode, data: { ...state.selectedNode.data, ...newData } }
+              : state.selectedNode;
+
+          return { nodes, selectedNode };
+        });
       },
       
 


### PR DESCRIPTION
## Summary
- update `setNodeData` so the selected node stays in sync
- verify `selectedNode` is updated in unit tests

## Testing
- `npm run lint`
- `yarn test` *(fails: `.env.test` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68531ab90afc8329abb97f6db76ea1b2