### PR TITLE
Fix Gmail send email panel layout

### DIFF
--- a/src/components/ui/side-panel.tsx
+++ b/src/components/ui/side-panel.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import { Drawer, DrawerContent, DrawerHeader, DrawerTitle } from '@/components/ui/drawer';
+import { ScrollArea } from '@/components/ui/scroll-area';
 import { useAppStore } from '@/store';
 import { useShallow } from 'zustand/react/shallow';
 import { AppNode } from '@/components/nodes';
@@ -18,13 +19,15 @@ export function SidePanel() {
 
   return (
     <Drawer open={!!selectedNode} onClose={clearSelectedNode}>
-      <DrawerContent className="ml-auto mr-0 right-0 top-0 h-screen w-[400px] z-50 shadow-lg">
+      <DrawerContent className="ml-auto mr-0 right-0 top-0 h-screen w-[400px] z-50 shadow-lg overflow-y-auto">
         <DrawerHeader>
-          <DrawerTitle>{selectedNode?.data?.title || "Details"}</DrawerTitle>
+          <DrawerTitle>{selectedNode?.data?.title || 'Details'}</DrawerTitle>
         </DrawerHeader>
-        {selectedNode && (
-          <NodeDetailFromRegistry node={selectedNode} setNodeData={setNodeData} />
-        )}
+        <ScrollArea className="p-4">
+          {selectedNode && (
+            <NodeDetailFromRegistry node={selectedNode} setNodeData={setNodeData} />
+          )}
+        </ScrollArea>
       </DrawerContent>
     </Drawer>
   );


### PR DESCRIPTION
## Summary
- add missing ScrollArea to the side panel
- enable vertical scrolling of action details

## Testing
- `npm run lint`
- `yarn test` *(fails: Cannot find package 'pg')*

------
https://chatgpt.com/codex/tasks/task_e_68531cf3d48483299fe5a6762106733f