### PR TITLE
Add local app fallback

### DIFF
--- a/src/app/api/apps/route.ts
+++ b/src/app/api/apps/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { localApps } from '@/lib/local-apps';
 
 const backendUrl = process.env.BACKEND_URL || 'http://localhost:3000';
 
@@ -11,12 +12,14 @@ export async function GET(request: NextRequest) {
       headers['Authorization'] = token;
     }
     const res = await fetch(url, { headers });
-
-    return new NextResponse(res.body, {
-      status: res.status,
-      headers: res.headers,
-    });
+    if (res.ok) {
+      return new NextResponse(res.body, {
+        status: res.status,
+        headers: res.headers,
+      });
+    }
+    throw new Error(`Backend error: ${res.status}`);
   } catch (error: any) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
+    return NextResponse.json({ data: localApps }, { status: 200 });
   }
 }

--- a/src/hooks/use-apps.ts
+++ b/src/hooks/use-apps.ts
@@ -1,7 +1,7 @@
 'use client';
 import { useEffect, useState } from 'react';
 import { getAuthToken } from '@/lib/auth';
-import { mockApps } from '@/data/mock-apps';
+import { localApps } from '@/lib/local-apps';
 
 export function useApps() {
   const [apps, setApps] = useState<any[] | null>(null);
@@ -23,7 +23,7 @@ export function useApps() {
         const json = await res.json();
         setApps(json.data);
       } catch (err) {
-        setApps(mockApps);
+        setApps(localApps);
         setError(err as Error);
       } finally {
         setIsLoading(false);

--- a/src/lib/local-apps.ts
+++ b/src/lib/local-apps.ts
@@ -1,0 +1,31 @@
+import fs from 'fs';
+import path from 'path';
+
+export interface LocalApp {
+  key: string;
+  name: string;
+}
+
+function loadLocalApps(): LocalApp[] {
+  const appsDir = path.join(process.cwd(), 'automat/packages/backend/src/apps');
+  if (!fs.existsSync(appsDir)) return [];
+
+  return fs
+    .readdirSync(appsDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => {
+      const dirPath = path.join(appsDir, entry.name);
+      const indexFile = fs
+        .readdirSync(dirPath)
+        .find((f) => /^index.*\.js$/.test(f));
+      if (!indexFile) return null;
+      const content = fs.readFileSync(path.join(dirPath, indexFile), 'utf8');
+      const nameMatch = content.match(/name:\s*['"`]([^'"`]+)['"`]/);
+      const keyMatch = content.match(/key:\s*['"`]([^'"`]+)['"`]/);
+      if (!nameMatch || !keyMatch) return null;
+      return { key: keyMatch[1], name: nameMatch[1] } as LocalApp;
+    })
+    .filter(Boolean) as LocalApp[];
+}
+
+export const localApps: LocalApp[] = loadLocalApps();


### PR DESCRIPTION
## Summary
- generate a list of apps by scanning backend sources
- fallback to local apps when backend fetch fails
- use local app list in `useApps`

## Testing
- `npm run lint`
- `yarn test` *(fails: Cannot find package 'pg')*

------
https://chatgpt.com/codex/tasks/task_e_68531c97cecc8329bc52aeb1e0d9045f