### PR TITLE
Use mock apps fallback on client

### DIFF
--- a/src/hooks/use-apps.ts
+++ b/src/hooks/use-apps.ts
@@ -1,7 +1,7 @@
 'use client';
 import { useEffect, useState } from 'react';
 import { getAuthToken } from '@/lib/auth';
-import { localApps } from '@/lib/local-apps';
+import { mockApps } from '@/data/mock-apps';
 
 export function useApps() {
   const [apps, setApps] = useState<any[] | null>(null);
@@ -23,7 +23,7 @@ export function useApps() {
         const json = await res.json();
         setApps(json.data);
       } catch (err) {
-        setApps(localApps);
+        setApps(mockApps);
         setError(err as Error);
       } finally {
         setIsLoading(false);


### PR DESCRIPTION
## Summary
- use `mockApps` fallback in `useApps` hook to avoid importing `fs`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `cd automat/packages/backend && yarn test` *(fails: cannot find package 'pg')*


------
https://chatgpt.com/codex/tasks/task_e_68531e59c0e483298bb1c827276315d0