### PR TITLE
Add local actions fallback

### DIFF
--- a/src/app/api/apps/[appKey]/actions/route.ts
+++ b/src/app/api/apps/[appKey]/actions/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { localActions } from '@/lib/local-actions';
 
 export const dynamic = 'force-dynamic';
 
@@ -23,6 +24,7 @@ export async function GET(
       headers: res.headers,
     });
   } catch (error: any) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
+    const fallback = localActions[appKey] || [];
+    return NextResponse.json({ data: fallback }, { status: 200 });
   }
 }

--- a/src/hooks/use-actions.ts
+++ b/src/hooks/use-actions.ts
@@ -2,6 +2,7 @@
 import { useEffect, useState } from 'react';
 import { getAuthToken } from '@/lib/auth';
 import { mockActions } from '@/data/mock-actions';
+import { localActions } from '@/lib/local-actions';
 
 export function useActions(appKey?: string) {
   const [actions, setActions] = useState<any[] | null>(null);
@@ -26,7 +27,7 @@ export function useActions(appKey?: string) {
         const json = await res.json();
         setActions(json.data);
       } catch (err) {
-        setActions(mockActions[appKey] || []);
+        setActions(localActions[appKey] || mockActions[appKey] || []);
         setError(err as Error);
       } finally {
         setIsLoading(false);

--- a/src/lib/local-actions.ts
+++ b/src/lib/local-actions.ts
@@ -1,0 +1,48 @@
+import fs from 'fs';
+import path from 'path';
+
+export interface LocalAction {
+  key: string;
+  name: string;
+}
+
+export type LocalActionsMap = Record<string, LocalAction[]>;
+
+function loadLocalActions(): LocalActionsMap {
+  const appsDir = path.join(process.cwd(), 'automat/packages/backend/src/apps');
+  if (!fs.existsSync(appsDir)) return {};
+
+  const result: LocalActionsMap = {};
+
+  for (const appEntry of fs.readdirSync(appsDir, { withFileTypes: true })) {
+    if (!appEntry.isDirectory()) continue;
+    const appKey = appEntry.name;
+    const actionsDir = path.join(appsDir, appKey, 'actions');
+    if (!fs.existsSync(actionsDir)) continue;
+
+    const actions: LocalAction[] = [];
+
+    for (const actionEntry of fs.readdirSync(actionsDir, { withFileTypes: true })) {
+      if (!actionEntry.isDirectory()) continue;
+      const actionDir = path.join(actionsDir, actionEntry.name);
+      const indexFile = fs
+        .readdirSync(actionDir)
+        .find((f) => /^index.*\.js$/.test(f));
+      if (!indexFile) continue;
+      const content = fs.readFileSync(path.join(actionDir, indexFile), 'utf8');
+      const nameMatch = content.match(/name:\s*['"`]([^'"`]+)['"`]/);
+      const keyMatch = content.match(/key:\s*['"`]([^'"`]+)['"`]/);
+      if (nameMatch && keyMatch) {
+        actions.push({ key: keyMatch[1], name: nameMatch[1] });
+      }
+    }
+
+    if (actions.length > 0) {
+      result[appKey] = actions;
+    }
+  }
+
+  return result;
+}
+
+export const localActions: LocalActionsMap = loadLocalActions();


### PR DESCRIPTION
## Summary
- expose local actions from backend packages
- use local fallback when retrieving actions

## Testing
- `npm run lint`
- `yarn test` *(fails: Test environment file (.env.test) not found)*

------
https://chatgpt.com/codex/tasks/task_e_685320b6263483298b3f8f4df430ea2c