### PR TITLE
Update action fetch fallback

### DIFF
--- a/src/hooks/use-actions.ts
+++ b/src/hooks/use-actions.ts
@@ -2,7 +2,6 @@
 import { useEffect, useState } from 'react';
 import { getAuthToken } from '@/lib/auth';
 import { mockActions } from '@/data/mock-actions';
-import { localActions } from '@/lib/local-actions';
 
 export function useActions(appKey?: string) {
   const [actions, setActions] = useState<any[] | null>(null);
@@ -27,7 +26,7 @@ export function useActions(appKey?: string) {
         const json = await res.json();
         setActions(json.data);
       } catch (err) {
-        setActions(localActions[appKey] || mockActions[appKey] || []);
+        setActions(mockActions[appKey] || []);
         setError(err as Error);
       } finally {
         setIsLoading(false);


### PR DESCRIPTION
## Summary
- revert `useActions` hook to rely solely on mocked actions
- keep server route fallback using `localActions`

## Testing
- `npm run lint`
- `yarn test` from `automat/packages/backend` *(fails: Cannot find package 'pg')*

------
https://chatgpt.com/codex/tasks/task_e_6853238180708329b49233ed4113d220