### PR TITLE
Add Airtable to mock actions

### DIFF
--- a/src/data/mock-actions.ts
+++ b/src/data/mock-actions.ts
@@ -11,6 +11,10 @@ export const mockActions: Record<string, { key: string; name: string }[]> = {
     { key: 'create-issue', name: 'Create Issue' },
     { key: 'list-repos', name: 'List Repositories' },
   ],
+  airtable: [
+    { key: 'createRecord', name: 'Create record' },
+    { key: 'findRecord', name: 'Find record' },
+  ],
   notion: [
     { key: 'create-page', name: 'Create Page' },
     { key: 'update-database', name: 'Update Database' },


### PR DESCRIPTION
## Summary
- add mock action list for Airtable so actions appear without backend

## Testing
- `npm run lint`
- `yarn test` *(fails: `.env.test` missing)*

------
https://chatgpt.com/codex/tasks/task_e_6853251cfd308329ba87b7034dc8812b