### PR TITLE
Fix workflow runner hook dependencies

### DIFF
--- a/src/hooks/use-workflow-runner.tsx
+++ b/src/hooks/use-workflow-runner.tsx
@@ -74,23 +74,26 @@ export function useWorkflowRunner() {
   );
   
 
-  const executeWorkflowFromNode = async (
-    nodeId: string,
-    nodesMap: Map<string, AppNode>,
-    edgesMap: Map<string, AppEdge[]>
-  ) => {
-    if (!isRunning.current) return;
+  const executeWorkflowFromNode = useCallback(
+    async (
+      nodeId: string,
+      nodesMap: Map<string, AppNode>,
+      edgesMap: Map<string, AppEdge[]>
+    ) => {
+      if (!isRunning.current) return;
 
-    const node = nodesMap.get(nodeId);
-    if (!node) return;
+      const node = nodesMap.get(nodeId);
+      if (!node) return;
 
-    await processNode(node);
+      await processNode(node);
 
-    const outgoingEdges = edgesMap.get(nodeId) || [];
-    for (const edge of outgoingEdges) {
-      await executeWorkflowFromNode(edge.target, nodesMap, edgesMap);
-    }
-  };
+      const outgoingEdges = edgesMap.get(nodeId) || [];
+      for (const edge of outgoingEdges) {
+        await executeWorkflowFromNode(edge.target, nodesMap, edgesMap);
+      }
+    },
+    [processNode]
+  );
 
   const runWorkflow = useCallback(
     async (startNodeId?: string) => {
@@ -124,7 +127,7 @@ export function useWorkflowRunner() {
 
       isRunning.current = false;
     },
-    [getNodes, getEdges, processNode, resetNodeStatus]
+    [getNodes, getEdges, executeWorkflowFromNode, resetNodeStatus]
   );
 
   return {


### PR DESCRIPTION
## Summary
- wrap `executeWorkflowFromNode` in `useCallback`
- include `executeWorkflowFromNode` in `runWorkflow` dependencies

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68533179586083298a5ab77480501309