### PR TITLE
Handle missing DeepSeek API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,13 @@ DEEPSEEK_API_KEY=your-deepseek-api-key
 
 The `DEEPSEEK_API_KEY` is required for the AI Workflow Generator node.
 
+## Environment Variables
+
+Create a `.env.local` file and define these variables:
+
+- `BACKEND_URL` – Base URL for the backend service.
+- `DEEPSEEK_API_KEY` – Required for the `/api/deepseek` route.
+
 ## API Routes
 
 These routes proxy requests to the backend using the `BACKEND_URL` value:

--- a/src/app/api/deepseek/route.ts
+++ b/src/app/api/deepseek/route.ts
@@ -2,7 +2,14 @@ import { NextRequest, NextResponse } from 'next/server';
 
 const DEEPSEEK_API_KEY = process.env.DEEPSEEK_API_KEY;
 export async function POST(request: NextRequest) {
-    const { prompt } = await request.json();
+  if (!DEEPSEEK_API_KEY) {
+    return NextResponse.json(
+      { error: 'DEEPSEEK_API_KEY environment variable is not set' },
+      { status: 500 }
+    );
+  }
+
+  const { prompt } = await request.json();
   
     const response = await fetch('https://api.deepseek.com/chat/completions', {
       method: 'POST',


### PR DESCRIPTION
## Summary
- return 500 from DeepSeek API route when `DEEPSEEK_API_KEY` isn't set
- document `DEEPSEEK_API_KEY` environment variable

## Testing
- `npm run lint`
- `yarn test` *(fails: Test environment file (.env.test) not found)*

------
https://chatgpt.com/codex/tasks/task_e_685331822c788329b43e5f1a45b5f769