### PR TITLE
Add landing page route

### DIFF
--- a/src/app/landing/layout.tsx
+++ b/src/app/landing/layout.tsx
@@ -1,0 +1,20 @@
+import { ReactNode } from 'react';
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+
+export default function LandingLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex min-h-screen flex-col">
+      <header className="flex items-center justify-between px-6 py-4">
+        <span className="text-lg font-semibold">Flowstate</span>
+        <Button asChild>
+          <Link href="/">Launch App</Link>
+        </Button>
+      </header>
+      <main className="flex flex-1 flex-col">{children}</main>
+      <footer className="px-6 py-4 text-center text-sm text-muted-foreground">
+        © {new Date().getFullYear()} Flowstate
+      </footer>
+    </div>
+  );
+}

--- a/src/app/landing/page.tsx
+++ b/src/app/landing/page.tsx
@@ -1,0 +1,38 @@
+import { Rocket, CheckCircle2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+function Feature({ icon: Icon, title, description }: { icon: React.FC<any>; title: string; description: string }) {
+  return (
+    <div className="flex flex-col items-center gap-2 text-center">
+      <Icon className="size-8 text-primary" />
+      <h3 className="text-lg font-semibold">{title}</h3>
+      <p className="text-sm text-muted-foreground">{description}</p>
+    </div>
+  );
+}
+
+export default function LandingPage() {
+  return (
+    <div className="flex flex-col items-center gap-16 px-6 py-12">
+      <section className="flex max-w-2xl flex-col items-center gap-6 text-center">
+        <h1 className="text-4xl font-bold">Automate your workflows</h1>
+        <p className="text-muted-foreground">
+          Build complex automations with an intuitive drag-and-drop editor.
+        </p>
+        <Button size="lg">Get Started</Button>
+      </section>
+      <section className="grid w-full max-w-4xl grid-cols-1 gap-8 sm:grid-cols-2">
+        <Feature
+          icon={Rocket}
+          title="Fast Setup"
+          description="Create workflows in minutes with prebuilt nodes."
+        />
+        <Feature
+          icon={CheckCircle2}
+          title="Reliable"
+          description="Run your automations with confidence and visibility."
+        />
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add new `/landing` route with header and footer layout
- build simple marketing page with hero section and features

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6855b5d8ea8083298c47d4d2144a9bec