### PR TITLE
Add apps integrations page

### DIFF
--- a/src/app/api/apps/[appKey]/connections/route.ts
+++ b/src/app/api/apps/[appKey]/connections/route.ts
@@ -26,3 +26,26 @@ export async function GET(
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
 }
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { appKey: string } }
+) {
+  const { appKey } = params
+  const token = request.headers.get('authorization')
+  try {
+    const url = `${backendUrl}/internal/api/v1/apps/${appKey}/connections`
+    const body = await request.text()
+    const headers: HeadersInit = { 'Content-Type': 'application/json' }
+    if (token) {
+      headers['Authorization'] = token
+    }
+    const res = await fetch(url, { method: 'POST', headers, body })
+    return new NextResponse(res.body, {
+      status: res.status,
+      headers: res.headers,
+    })
+  } catch (error: any) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+}

--- a/src/app/api/connections/[connectionId]/route.ts
+++ b/src/app/api/connections/[connectionId]/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export const dynamic = 'force-dynamic'
+
+const backendUrl = process.env.BACKEND_URL || 'http://localhost:3000'
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: { connectionId: string } }
+) {
+  const { connectionId } = params
+  const token = request.headers.get('authorization')
+  try {
+    const url = `${backendUrl}/internal/api/v1/connections/${connectionId}`
+    const headers: HeadersInit = {}
+    if (token) {
+      headers['Authorization'] = token
+    }
+    const res = await fetch(url, { method: 'DELETE', headers })
+    return new NextResponse(null, { status: res.status })
+  } catch (error: any) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+}

--- a/src/app/apps/page.tsx
+++ b/src/app/apps/page.tsx
@@ -1,0 +1,107 @@
+'use client'
+
+import { useState } from 'react'
+import SidebarLayout from '@/components/layouts/sidebar-layout'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
+import AddConnectionForm from '@/components/add-connection-form'
+import { useApps } from '@/hooks/use-apps'
+import { useConnections } from '@/hooks/use-connections'
+
+function ConnectionsList({
+  appKey,
+  onRefresh,
+}: {
+  appKey: string
+  onRefresh: () => void
+}) {
+  const { connections, isLoading } = useConnections(appKey)
+  const handleDelete = async (id: string) => {
+    await fetch(`/api/connections/${id}`, { method: 'DELETE' })
+    onRefresh()
+  }
+  return (
+    <div className='space-y-2'>
+      {isLoading && <p>Loading...</p>}
+      {!isLoading &&
+        connections?.map((c) => (
+          <div key={c.id} className='flex items-center justify-between'>
+            <span>{c.name || c.id}</span>
+            <Button
+              variant='ghost'
+              size='sm'
+              onClick={() => handleDelete(c.id)}
+            >
+              Delete
+            </Button>
+          </div>
+        ))}
+    </div>
+  )
+}
+
+export default function AppsPage() {
+  const { apps, isLoading } = useApps()
+  const [selected, setSelected] = useState<string | null>(null)
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [refresh, setRefresh] = useState(0)
+
+  const refreshConnections = () => setRefresh((r) => r + 1)
+
+  return (
+    <SidebarLayout>
+      <div className='flex h-full p-4 gap-8'>
+        <div className='w-64 space-y-2'>
+          <h2 className='font-semibold'>Apps</h2>
+          {isLoading && <p>Loading...</p>}
+          {!isLoading &&
+            apps?.map((app) => (
+              <Button
+                key={app.key}
+                variant={selected === app.key ? 'secondary' : 'outline'}
+                className='w-full justify-start'
+                onClick={() => setSelected(app.key)}
+              >
+                {app.name}
+              </Button>
+            ))}
+        </div>
+        {selected && (
+          <div className='flex-1 space-y-4'>
+            <div className='flex items-center justify-between'>
+              <h2 className='font-semibold'>Connections</h2>
+              <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+                <DialogTrigger asChild>
+                  <Button size='sm'>Add connection</Button>
+                </DialogTrigger>
+                <DialogContent>
+                  <DialogHeader>
+                    <DialogTitle>Add Connection</DialogTitle>
+                  </DialogHeader>
+                  <AddConnectionForm
+                    appKey={selected}
+                    onSuccess={() => {
+                      setDialogOpen(false)
+                      refreshConnections()
+                    }}
+                  />
+                </DialogContent>
+              </Dialog>
+            </div>
+            <ConnectionsList
+              key={refresh}
+              appKey={selected}
+              onRefresh={refreshConnections}
+            />
+          </div>
+        )}
+      </div>
+    </SidebarLayout>
+  )
+}

--- a/src/components/add-connection-form.tsx
+++ b/src/components/add-connection-form.tsx
@@ -1,0 +1,48 @@
+'use client'
+
+import { useState } from 'react'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+
+export default function AddConnectionForm({
+  appKey,
+  onSuccess,
+}: {
+  appKey: string
+  onSuccess: () => void
+}) {
+  const [screenName, setScreenName] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setLoading(true)
+    try {
+      const res = await fetch(`/api/apps/${appKey}/connections`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ formattedData: { screenName } }),
+      })
+      if (!res.ok) throw new Error('Failed to create connection')
+      setScreenName('')
+      onSuccess()
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <form onSubmit={onSubmit} className='space-y-4'>
+      <Input
+        placeholder='Connection name'
+        value={screenName}
+        onChange={(e) => setScreenName(e.target.value)}
+      />
+      <div className='flex justify-end'>
+        <Button type='submit' disabled={loading}>
+          Save
+        </Button>
+      </div>
+    </form>
+  )
+}


### PR DESCRIPTION
## Summary
- show apps list and connections under `/apps`
- add form to create a connection
- support deleting connections
- proxy POST and DELETE APIs for connections

## Testing
- `npm run lint`
- `cd automat/packages/backend && yarn test` *(fails: Cannot find package 'pg')*

------
https://chatgpt.com/codex/tasks/task_e_6855d8594d3883299a24d2a591f6068e