### PR TITLE
Add waitlist support

### DIFF
--- a/automat/packages/backend/src/db/migrations/20250620221805_create_waitlist.js
+++ b/automat/packages/backend/src/db/migrations/20250620221805_create_waitlist.js
@@ -1,0 +1,12 @@
+export async function up(knex) {
+  return knex.schema.createTable('waitlist', table => {
+    table.uuid('id').primary().defaultTo(knex.raw('gen_random_uuid()'))
+    table.string('name')
+    table.string('email').notNullable()
+    table.timestamp('created_at').defaultTo(knex.fn.now())
+  })
+}
+
+export async function down(knex) {
+  return knex.schema.dropTable('waitlist')
+}

--- a/src/app/api/waitlist/route.ts
+++ b/src/app/api/waitlist/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export const dynamic = 'force-dynamic'
+
+const backendUrl = process.env.BACKEND_URL || 'http://localhost:3000'
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.text()
+    const res = await fetch(`${backendUrl}/internal/api/v1/waitlist`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body,
+    })
+    const data = await res.json()
+    return NextResponse.json(data, { status: res.status })
+  } catch (error: any) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+}

--- a/workflow-backend/src/index.ts
+++ b/workflow-backend/src/index.ts
@@ -29,6 +29,14 @@ async function init() {
       edges jsonb
     );
   `);
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS waitlist (
+      id uuid PRIMARY KEY,
+      name text,
+      email text NOT NULL,
+      created_at timestamptz NOT NULL DEFAULT now()
+    );
+  `);
 }
 
 init().catch(err => console.error('DB init failed', err));
@@ -65,6 +73,16 @@ app.post('/internal/api/v1/login', async (req, res) => {
   if (!match) return res.status(401).json({ success: false });
   const token = jwt.sign({ userId: user.id }, process.env.JWT_SECRET as string);
   res.json({ success: true, token });
+});
+
+app.post('/internal/api/v1/waitlist', async (req, res) => {
+  const { name, email } = req.body;
+  if (!email) return res.status(400).json({ success: false });
+  await pool.query(
+    'INSERT INTO waitlist (id, name, email, created_at) VALUES (gen_random_uuid(), $1, $2, now())',
+    [name || null, email]
+  );
+  res.json({ success: true });
 });
 
 app.post('/internal/api/v1/workflows', auth, async (req, res) => {


### PR DESCRIPTION
## Summary
- create a database migration for a new `waitlist` table
- expose `/internal/api/v1/waitlist` in the example backend
- proxy `/api/waitlist` to the backend

## Testing
- `npm run lint`
- `yarn test` *(fails: .env config and other setup issues)*

------
https://chatgpt.com/codex/tasks/task_e_6855dd1471448329b6d62fff84c5d690