### PR TITLE
Add waitlist support

### DIFF
--- a/automat/packages/backend/src/db/migrations/20250620221805_create_waitlist.js
+++ b/automat/packages/backend/src/db/migrations/20250620221805_create_waitlist.js
@@ -1,0 +1,11 @@
+export async function up(knex) {
+  return knex.schema.createTable('waitlist', table => {
+    table.string('name')
+    table.string('email').notNullable()
+    table.timestamp('created_at').defaultTo(knex.fn.now())
+  })
+}
+
+export async function down(knex) {
+  return knex.schema.dropTable('waitlist')
+}

--- a/src/app/api/waitlist/route.ts
+++ b/src/app/api/waitlist/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export const dynamic = 'force-dynamic'
+
+const backendUrl = process.env.BACKEND_URL || 'http://localhost:3000'
+
+export async function POST(request: NextRequest) {
+  try {
+    const payload = await request.json()
+    const body = JSON.stringify(payload)
+    const res = await fetch(`${backendUrl}/internal/api/v1/waitlist`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body,
+    })
+    const data = await res.json()
+    return NextResponse.json(data, { status: res.status })
+  } catch (error: any) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+}


### PR DESCRIPTION
## Summary
- create a database migration for a new `waitlist` table
- expose `/internal/api/v1/waitlist` in the example backend
- proxy `/api/waitlist` to the backend
- simplify schema by removing an unused `id` column

## Testing
- `npm run lint`
- `yarn test` *(fails: cannot find package 'pg' in backend config)*

------
https://chatgpt.com/codex/tasks/task_e_6855dd1471448329b6d62fff84c5d690